### PR TITLE
add date-from helper

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -50,6 +50,15 @@ You can get a date object from a natural human date (e.g. `tomorrow`, `2 weeks a
 {{format-date (date "last week") "timestamp"}}
 ```
 
+#### Date from natural string helper, based on a reference date
+
+You can also get a date object from a natural human date (e.g. `tomorrow`, `2 weeks ago`, `2022-03-24`), but from a given reference time, using the `{{date-from}}` helper. It is most useful when paired with the `{{format-date}}` helper.
+```
+{{ datefrom "2006-01-02" "1 day ago" }}
+
+{{format-date (date-from "2006-01-02" "next monday") "timestamp"}}
+```
+
 #### Date formatting helper
 
 The `{{format-date}}` helper formats the given date for display.

--- a/internal/adapter/handlebars/handlebars.go
+++ b/internal/adapter/handlebars/handlebars.go
@@ -17,6 +17,7 @@ func Init(supportsUTF8 bool, logger util.Logger) {
 	helpers.RegisterConcat()
 	helpers.RegisterDate(logger)
 	helpers.RegisterFormatDate(logger)
+	helpers.RegisterDateFrom(logger)
 	helpers.RegisterJoin()
 	helpers.RegisterJSON(logger)
 	helpers.RegisterList(supportsUTF8)

--- a/internal/util/date/date.go
+++ b/internal/util/date/date.go
@@ -1,6 +1,7 @@
 package date
 
 import (
+	"fmt"
 	"time"
 
 	naturaldate "github.com/tj/go-naturaldate"
@@ -37,6 +38,20 @@ func (n *Frozen) Date() time.Time {
 
 // TimeFromNatural parses a human date into a time.Time.
 func TimeFromNatural(date string) (time.Time, error) {
+	if t, err := ParseTimestamp(date); err == nil {
+		return t, nil
+	}
+	return naturaldate.Parse(date, time.Now(), naturaldate.WithDirection(naturaldate.Past))
+}
+
+func TimeFromReference(date string, refTime time.Time) (time.Time, error) {
+	if t, err := ParseTimestamp(date); err == nil {
+		return t, nil
+	}
+	return naturaldate.Parse(date, refTime, naturaldate.WithDirection(naturaldate.Past))
+}
+
+func ParseTimestamp(date string) (time.Time, error) {
 	if date == "" {
 		return time.Now(), nil
 	}
@@ -61,5 +76,5 @@ func TimeFromNatural(date string) (time.Time, error) {
 	if t, err := time.ParseInLocation("15:04", date, time.Local); err == nil {
 		return t, nil
 	}
-	return naturaldate.Parse(date, time.Now(), naturaldate.WithDirection(naturaldate.Past))
+	return time.Time{}, fmt.Errorf("unable to parse reference time '%s'", date)
 }


### PR DESCRIPTION
Add a `{{date-from}}` template helper which takes in two arguments: reference time (either a string or a time.Time object) and a natural time string, and generates a new time object.

Behaves same as `{{date}}` but generates offsets based on the reference time.

Closes #357 

