### PR TITLE
fix day range parsing (zk-org/zk#382)

### DIFF
--- a/internal/cli/filtering.go
+++ b/internal/cli/filtering.go
@@ -280,7 +280,9 @@ func parseDayRange(date string) (start time.Time, end time.Time, err error) {
 		return
 	}
 
-	start = startOfDay(day)
+    // we add -1 second so that the day range ends at 23:59:59
+    // i.e, the 'new day' begins at 00:00:00
+	start = startOfDay(day).Add(time.Second * -1)
 	end = start.AddDate(0, 0, 1)
 	return start, end, nil
 }


### PR DESCRIPTION
fix: set day range end to be one second before midnight.

i.e, the next day begins at 00:00.

Now the day range extends to 23:59:59. Meaning that the notes created within the
same day, that do not have time stamps, will be returned by a query such as `zk
list --created=today`, previously would fall under `... --created=yesterday`.

Likewise, given a note with the YAML date `2024-01-22`, zk would report this as being
created on `2024-01-21`.

