### PR TITLE
tesh test case for yaml dates without time stamp

### DIFF
--- a/tests/fixtures/issue-382/.zk/config.toml
+++ b/tests/fixtures/issue-382/.zk/config.toml
@@ -1,0 +1,197 @@
+# zk configuration file
+#
+# Uncomment the properties you want to customize.
+
+# NOTE SETTINGS
+#
+# Defines the default options used when generating new notes.
+[note]
+
+# Language used when writing notes.
+# This is used to generate slugs or with date formats.
+#language = "en"
+
+# The default title used for new note, if no `--title` flag is provided.
+#default-title = "Untitled"
+
+# Template used to generate a note's filename, without extension.
+#filename = "{{id}}"
+
+# The file extension used for the notes.
+#extension = "md"
+
+# Template used to generate a note's content.
+# If not an absolute path, it is relative to .zk/templates/
+template = "default.md"
+
+# Path globs ignored while indexing existing notes.
+#ignore = [
+#    "drafts/*",
+#	"log.md"
+#]
+
+# Configure random ID generation.
+
+# The charset used for random IDs. You can use:
+#   * letters: only letters from a to z.
+#   * numbers: 0 to 9
+#   * alphanum: letters + numbers
+#   * hex: hexadecimal, from a to f and 0 to 9
+#   * custom string: will use any character from the provided value
+#id-charset = "alphanum"
+
+# Length of the generated IDs.
+#id-length = 4
+
+# Letter case for the random IDs, among lower, upper or mixed.
+#id-case = "lower"
+
+
+# EXTRA VARIABLES
+#
+# A dictionary of variables you can use for any custom values when generating
+# new notes. They are accessible in templates with {{extra.<key>}}
+[extra]
+
+#key = "value"
+
+
+# GROUP OVERRIDES
+#
+# You can override global settings from [note] and [extra] for a particular
+# group of notes by declaring a [group."<name>"] section.
+#
+# Specify the list of directories which will automatically belong to the group
+# with the optional `paths` property.
+#
+# Omitting `paths` is equivalent to providing a single path equal to the name of
+# the group. This can be useful to quickly declare a group by the name of the
+# directory it applies to.
+
+#[group."<NAME>"]
+#paths = ["<DIR1>", "<DIR2>"]
+#[group."<NAME>".note]
+#filename = "{{format-date now}}"
+#[group."<NAME>".extra]
+#key = "value"
+
+
+# MARKDOWN SETTINGS
+[format.markdown]
+
+# Format used to generate links between notes.
+# Either "wiki", "markdown" or a custom template. Default is "markdown".
+#link-format = "wiki"
+# Indicates whether a link's path will be percent-encoded.
+# Defaults to true for "markdown" format and false for "wiki" format.
+#link-encode-path = true
+# Indicates whether a link's path file extension will be removed.
+# Defaults to true.
+#link-drop-extension = true
+
+# Enable support for #hashtags.
+hashtags = false
+# Enable support for :colon:separated:tags:.
+colon-tags = false
+# Enable support for Bear's #multi-word tags#
+# Hashtags must be enabled for multi-word tags to work.
+multiword-tags = false
+
+
+# EXTERNAL TOOLS
+[tool]
+
+# Default editor used to open notes. When not set, the EDITOR or VISUAL
+# environment variables are used.
+#editor = "vim"
+
+# Pager used to scroll through long output. If you want to disable paging
+# altogether, set it to an empty string "".
+#pager = "less -FIRX"
+
+# Command used to preview a note during interactive fzf mode.
+# Set it to an empty string "" to disable preview.
+
+# bat is a great tool to render Markdown document with syntax highlighting.
+#https://github.com/sharkdp/bat
+#fzf-preview = "bat -p --color always {-1}"
+
+
+# LSP
+#
+#   Configure basic editor integration for LSP-compatible editors.
+#   See https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md
+#
+[lsp]
+
+[lsp.diagnostics]
+# Each diagnostic can have for value: none, hint, info, warning, error
+
+# Report titles of wiki-links as hints.
+#wiki-title = "hint"
+# Warn for dead links between notes.
+dead-link = "error"
+
+[lsp.completion]
+# Customize the completion pop-up of your LSP client.
+
+# Show the note title in the completion pop-up, or fallback on its path if empty.
+#note-label = ""
+# Filter out the completion pop-up using the note title or its path.
+#note-filter-text = " "
+# Show the note filename without extension as detail.
+#note-detail = ""
+
+
+# NAMED FILTERS
+#
+#    A named filter is a set of note filtering options used frequently together.
+#
+[filter]
+
+# Matches the notes created the last two weeks. For example:
+#    $ zk list recents --limit 15
+#    $ zk edit recents --interactive
+#recents = "--sort created- --created-after 'last two weeks'"
+
+
+# COMMAND ALIASES
+#
+#   Aliases are user commands called with `zk <alias> [<flags>] [<args>]`.
+#
+#   The alias will be executed with `$SHELL -c`, please refer to your shell's
+#   man page to see the available syntax. In most shells:
+#     * $@ can be used to expand all the provided flags and arguments
+#     * you can pipe commands together with the usual | character
+#
+[alias]
+# Here are a few aliases to get you started.
+
+# Shortcut to a command.
+#ls = "zk list $@"
+
+# Default flags for an existing command.
+#list = "zk list --quiet $@"
+
+# Edit the last modified note.
+#editlast = "zk edit --limit 1 --sort modified- $@"
+
+# Edit the notes selected interactively among the notes created the last two weeks.
+# This alias doesn't take any argument, so we don't use $@.
+#recent = "zk edit --sort created- --created-after 'last two weeks' --interactive"
+
+# Print paths separated with colons for the notes found with the given
+# arguments. This can be useful to expand a complex search query into a flag
+# taking only paths. For example:
+#   zk list --link-to "`zk path -m potatoe`"
+#path = "zk list --quiet --format {{path}} --delimiter , $@"
+
+# Show a random note.
+#lucky = "zk list --quiet --format full --sort random --limit 1"
+
+# Returns the Git history for the notes found with the given arguments.
+# Note the use of a pipe and the location of $@.
+#hist = "zk list --format path --delimiter0 --quiet $@ | xargs -t -0 git log --patch --"
+
+# Edit this configuration file.
+#conf = '$EDITOR "$ZK_NOTEBOOK_DIR/.zk/config.toml"'

--- a/tests/fixtures/issue-382/.zk/templates/default.md
+++ b/tests/fixtures/issue-382/.zk/templates/default.md
@@ -1,0 +1,7 @@
+---
+date: {{format-date now}}
+---
+
+# {{title}}
+
+{{content}}

--- a/tests/fixtures/issue-382/333h.md
+++ b/tests/fixtures/issue-382/333h.md
@@ -1,0 +1,8 @@
+---
+date: 2024-01-24
+---
+
+# no timestamp
+
+This note should be returned when querying for it's date.
+

--- a/tests/issue-382.tesh
+++ b/tests/issue-382.tesh
@@ -1,0 +1,6 @@
+$ cd issue-382
+
+# A note without a YAML timestamp should be returned 
+# when querying its creation day.
+$ zk list -q --created 2024-01-24 --format "\{{path}}: \{{format-date created 'short'}}"
+>333h.md: 01/24/2024


### PR DESCRIPTION
This adds a test case for zk-org/zk#382 which found that dates without time
stamps in yaml frontmatter were causing the respective note to be returned when
quering the day *before* the note creation.

The test case was tested against commit 55d5487, which was before this 
bug was resolved: the test failed (the note from 24th of Jan was returned when querying 
for notes created on the 23rd of jan)

Ran again against the current commit (post zk-org/zk#382 being resolved) and it
passes.

Also, in contributing.md, mickael wrote that it's good practice that we make a test fixture per issue with tesh tests. 
But there was already a tests/markdown-yaml-frontmatter.tesh file. 

Should I instead add this new test coverage to that test fixture?
