### PR TITLE
accept tripple dash file URIs as valid links

### DIFF
--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"unicode/utf16"
 
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
 	"github.com/zk-org/zk/internal/core"
 	"github.com/zk-org/zk/internal/util"
 	"github.com/zk-org/zk/internal/util/errors"
 	strutil "github.com/zk-org/zk/internal/util/strings"
-	"github.com/tliron/glsp"
-	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
 // documentStore holds opened documents.
@@ -228,23 +228,24 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 			})
 		}
 
-        // extract link paths from [title](path) patterns
-        for _, match := range 
-        markdownLinkRegex.FindAllStringSubmatchIndex(line, -1) {
-            // case: '!' ignores embedded image, e.g. ![title](href.png)
-            // case: '/' ignores tripple dash file URIs, e.g. file:///file.go
-			if match[0] > 0 && line[match[0]-1] == '!' || line[match[3]+8] == '/' {
+		// extract link paths from [title](path) patterns
+		for _, match := range markdownLinkRegex.FindAllStringSubmatchIndex(line, -1) {
+            // Ignore embedded images ![title](file.png) and tripple dash file 
+            // URIs [title](file:///file.go)
+			if (match[0] > 0 && line[match[0]-1] == '!') ||
+				(match[0] > 0 && line[match[3]+8] == '/') {
 				continue
 			}
 
 			href := line[match[4]:match[5]]
-			// Valid Markdown links are percent-encoded.
+
+			// Decode the href if it's percent-encoded
 			if decodedHref, err := url.PathUnescape(href); err == nil {
 				href = decodedHref
 			}
+
 			appendLink(href, match[0], match[1], false, false)
 		}
-
 
 		for _, match := range wikiLinkRegex.FindAllStringSubmatchIndex(line, -1) {
 			href := line[match[2]:match[3]]

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -228,9 +228,12 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 			})
 		}
 
-		for _, match := range markdownLinkRegex.FindAllStringSubmatchIndex(line, -1) {
-			// Ignore embedded image, e.g. ![title](href.png)
-			if match[0] > 0 && line[match[0]-1] == '!' {
+        // extract link paths from [title](path) patterns
+        for _, match := range 
+        markdownLinkRegex.FindAllStringSubmatchIndex(line, -1) {
+            // case: '!' ignores embedded image, e.g. ![title](href.png)
+            // case: '/' ignores tripple dash file URIs, e.g. file:///file.go
+			if match[0] > 0 && line[match[0]-1] == '!' || line[match[3]+8] == '/' {
 				continue
 			}
 
@@ -241,6 +244,7 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 			}
 			appendLink(href, match[0], match[1], false, false)
 		}
+
 
 		for _, match := range wikiLinkRegex.FindAllStringSubmatchIndex(line, -1) {
 			href := line[match[2]:match[3]]


### PR DESCRIPTION
PR to fix zk-org/zk#250. Links such as `[title](file:///file.go)` were returning an
lsp error "not found". The LSP does not actually check for the existence of
files via this format. Instead it was a symptom of the markdown link regex
checking, whereby the link was being understood as an internal markdown
document. Zk / lsp then tried to find the note `file:///file.example`, which it
if course couldn't, and so it was throwing the "not found" error.

This sollution copies the logic already present for embedded images, which is to
pick a defining syntactic element of the link (in this case, the third
occurrence of a '/' rune), and to skip that link with `continue`, effectively
ignoring it.
