### PR TITLE
Fix hyperlink from `README.md` to `docs/getting-started.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 <h1>zk</h1>
 <h4>A plain text note-taking assistant</h4>
 <img alt="Screencast" width="95%" src="docs/assets/media/screencast.svg"/>
-<p>Looking for a quick usage example? <a href="docs/getting-started.md">Let's get started</a>.</p>
 </div>
+
+Looking for a quick usage example? [Let's get started](docs/getting-started.md).
 
 ## News: We Are In Maintenance Mode
 


### PR DESCRIPTION
This PR fixes an issue with the hyperlink to the getting-started doc in the GitHub pages generated site. The `href` in the HTML `div` is not mapped correctly, so we move the link out of the div into a separate line. Doesn't look as pretty but should work as expected.