### PR TITLE
fix(lsp): fix trigger completion of zk LSP

### DIFF
--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -281,6 +281,9 @@ func (d *document) IsTagPosition(position protocol.Position, noteContentParser c
 	if targetWord == "" {
 		return false
 	}
+	if string(targetWord[0]) == "#" {
+		targetWord = targetWord[1:]
+	}
 
 	content := strings.Join(lines, "\n")
 	note, err := noteContentParser.ParseNoteContent(content)


### PR DESCRIPTION
This commit introduces trigger completion: until now zk LSP generated completion only on auto trigger. In particular this fixes https://github.com/zk-org/zk-nvim/issues/155

The completion bugs came from three sources: there was a wrong implementation of tag completion which forgot to ignore the '#' character, the completion function never made a call for trigger completion, and offset for `textEdit` on link completion was hardcoded to `-2` which is wrong if there is an additional text entered before a trigger is pressed. This commit fixes these three bugs.