### PR TITLE
fix(lsp): ignore diagnostic check within code blocks

### DIFF
--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -212,6 +212,8 @@ var insideFenced = false
 var insideIndented = false
 var currentCodeBlockStart = -1
 
+// check whether the current line in document is within a fenced or indented 
+// code block
 func isLineWithinCodeBlock(lines []string, lineIndex int, line string) bool {
     // if line is already within code fences or indented code block
 	if insideFenced {

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -323,7 +323,7 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
         // if there are an odd number of back ticks, the state of insideInline 
         // for the following link will be true
         if strings.Count(line, "`")%2 == 1 {
-			insideInline = !insideInline
+			insideInline = true
 		}
 	}
 

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -320,9 +320,7 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 			hasTitle := match[4] != -1
 			appendLink(href, match[0], match[1], hasTitle, true)
 		}
-        // if there are an odd number of back ticks, the state of insideInline 
-        // for the following link will be true
-        if strings.Count(line, "`")%2 == 1 {
+		if strings.Count(line, "`")%2 == 1 {
 			insideInline = !insideInline
 		}
 	}

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -197,9 +197,9 @@ func (d *document) DocumentLinkAt(pos protocol.Position) (*documentLink, error) 
 	return nil, nil
 }
 
-// Recursive function to check whether a link is within inline code block.
+// Recursive function to check whether a link is within inline code.
 func linkWithinInlineCode(strBuffer string, linkStart, linkEnd int, insideInline bool) bool {
-	if backtickId := strings.Index(strBuffer, "`"); backtickId > 0 && backtickId < linkEnd {
+	if backtickId := strings.Index(strBuffer, "`"); backtickId >= 0 && backtickId < linkEnd {
 		return linkWithinInlineCode(strBuffer[backtickId+1:],
 		linkStart-backtickId-1, linkEnd-backtickId-1, !insideInline)
 	} else {

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -323,7 +323,7 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
         // if there are an odd number of back ticks, the state of insideInline 
         // for the following link will be true
         if strings.Count(line, "`")%2 == 1 {
-			insideInline = true
+			insideInline = !insideInline
 		}
 	}
 

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -197,6 +197,7 @@ func (d *document) DocumentLinkAt(pos protocol.Position) (*documentLink, error) 
 	return nil, nil
 }
 
+// Recursive function to check whether a link is within inline code block.
 func linkWithinInlineCode(strBuffer string, linkStart, linkEnd int, insideInline bool) bool {
 	if backtickId := strings.Index(strBuffer, "`"); backtickId > 0 && backtickId < linkEnd {
 		return linkWithinInlineCode(strBuffer[backtickId+1:],
@@ -204,34 +205,6 @@ func linkWithinInlineCode(strBuffer string, linkStart, linkEnd int, insideInline
 	} else {
 		return insideInline
 	}
-
-		// backtickStart += cursorPos
-	//	if insideInline {
-	//		if backtickStart >= end {
-	//			return true
-	//		}
-	//		return linkWithinInlineCode(line[backtickStart+1:], start-backtickStart-1, end-backtickStart-1, false)
-	//	} else if backtickStart < start {
-	//		return linkWithinInlineCode(line[backtickStart+1:], start-backtickStart-1, end-backtickStart-1, !insideInline)
-	//	}
-
-	//	if backtickStart < start {
-	//		backtickEnd := strings.Index(line[backtickStart+1:], "`")
-	//		if backtickEnd >= 0 {
-	//			backtickEnd += backtickStart + 1
-	//			if backtickEnd >= end {
-	//				return true
-	//			} else {
-	//				return linkWithinInlineCode(line[backtickEnd+1:], start-backtickEnd-1, end-backtickEnd-1, false)
-	//			}
-	//		} else {
-	//			return true
-	//		}
-	//	}
-	//	return false
-	//} else {
-	//	return insideInline
-	//}
 }
 
 // DocumentLinks returns all the internal and external links found in the


### PR DESCRIPTION
resolves: #194.
resolves: https://github.com/zk-org/zk-nvim/issues/161

I tried to be as thorough as possible, let me know if I missed any other markdown ways to denote code blocks. I am also including here two files I have used to test this fix:
[empty-note.md](https://github.com/zk-org/zk/files/14841478/empty-note.md)
[test-note.md](https://github.com/zk-org/zk/files/14841479/test-note.md)
