### PR TITLE
fix quotes in titles breaking graph json output

### DIFF
--- a/internal/core/note_format.go
+++ b/internal/core/note_format.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"time"
+    "strings"
 )
 
 // NoteFormatter formats notes to be printed on the screen.
@@ -32,6 +33,11 @@ func newNoteFormatter(basePath string, template Template, linkFormatter LinkForm
 			snippets = append(snippets, noteTermRegex.ReplaceAllString(snippet, termRepl))
 		}
 
+        //FIXME: if notes have `"` in their titles, they will break when 
+        //executing `zk graph --format json` as `Link:...` gets unescaped quotes 
+        //from `newLazyStringer`. Issue: https://github.com/zk-org/zk/issues/389
+        // escaping the quotes breaks tesh tests, but is the test perhaps 
+        // guarding a less robust solution?
 		return template.Render(noteFormatRenderContext{
 			Filename:     note.Filename(),
 			FilenameStem: note.FilenameStem(),
@@ -44,6 +50,7 @@ func newNoteFormatter(basePath string, template Template, linkFormatter LinkForm
 					return ""
 				}
 				link, _ := linkFormatter(context)
+                link = strings.ReplaceAll(link, `"`, `\"`) // breaks tesh test
 				return link
 			}),
 			Lead:       note.Lead,


### PR DESCRIPTION
resolves: #389

note titles with `"` marks in them, eg `this is an "example" title`, are breaking the output of `zk graph --format json`.

The culprit is the template for the json format. I can't exactly track down where that is set, but it would seem deeper from `internal/core/notebook.go:336`.

In any case, this fix manually sanitizes the quote marks as they're being returned to the `Link` field, for output to json. Link output within documents (i.e, inserting wiki/markdown links in documents is not broken as that is handled separately in `internal/core/link_format.go`).

The caveat is that this fix breaks an old tesh test that looks at json output.

However, it would seem that the old tesh test is not taking into account note titles with `"` marks. 

Therefore, the failing test may be a sign of the test needing to be updated, rather than this fix being void?

In any case, this initial commit to the PR is effectively a draft. I'm looking for feedback about the above!

There is also [a discussion] in a previous issue which shows the development of the graph output, and also that [quotes in the titles are breaking its output](https://github.com/zk-org/zk/issues/48#issuecomment-863925549)
