### PR TITLE
fix: allow notebook to be a hidden dir

### DIFF
--- a/internal/core/note_index.go
+++ b/internal/core/note_index.go
@@ -150,7 +150,8 @@ func (t *indexTask) execute(callback func(change paths.DiffChange)) (NoteIndexin
 		return false, nil
 	}
 
-	source := paths.Walk(t.path, t.logger, shouldIgnorePath)
+    notebookPath := &NotebookPath{Path: t.path}
+	source := paths.Walk(t.path, t.logger, notebookPath.Filename(), shouldIgnorePath)
 
 	target, err := t.index.IndexedPaths()
 	if err != nil {

--- a/internal/util/paths/walk.go
+++ b/internal/util/paths/walk.go
@@ -10,7 +10,7 @@ import (
 
 // Walk emits the metadata of each file stored in the directory if they pass
 // the given shouldIgnorePath closure. Hidden files and directories are ignored.
-func Walk(basePath string, logger util.Logger, shouldIgnorePath func(string) (bool, error)) <-chan Metadata {
+func Walk(basePath string, logger util.Logger, notebookRoot string, shouldIgnorePath func(string) (bool, error)) <-chan Metadata {
 	c := make(chan Metadata, 50)
 	go func() {
 		defer close(c)
@@ -22,9 +22,10 @@ func Walk(basePath string, logger util.Logger, shouldIgnorePath func(string) (bo
 
 			filename := info.Name()
 			isHidden := strings.HasPrefix(filename, ".")
+			isNotebookRoot := filename == notebookRoot
 
 			if info.IsDir() {
-				if isHidden {
+				if isHidden && !isNotebookRoot {
 					return filepath.SkipDir
 				}
 


### PR DESCRIPTION
resolves: #271

The `index` function of `zk` calls a directory walk. That walk function was set to ignore all directories and files that had a period as a prefix. This applied then to the notebook root directory itself. This also effected commands such as `zk list`.

This fix is an initial approach to solving that by checking if the directory begins with a prefix _and_ the directory in question _does not_ equal the notebook root directory.

This equality check is done by getting the notebook directory from the `NotebookPath.Filename()` method, and checking it against the value of `filename` in `internal/util/paths/walk.go`.

Note: It was not possible to import the `core` package to `walk.go` as it created an import cycle. This is why it is instead accessed in `internal/core/note_index.go` line 153 and passed to the `paths.Walk()` call.

On that line (153), I'm unsure whether I've used the `NotebookPath` struct correctly as in other areas of the code base, _all_ fields of the struct are declared.

I have however tested this fix with success. That being a notebook with root dir `.test-vault`; `zk` indexes and lists correctly, meaning it ignores the `.zk` and `.git` directories as well as a `.test-file.md` note created via `zk`.

Please let me know if there is a better way to do this! 🙏
