### PR TITLE
Determine fixture path using the current working directory

### DIFF
--- a/internal/util/fixtures/fixtures.go
+++ b/internal/util/fixtures/fixtures.go
@@ -1,15 +1,15 @@
 package fixtures
 
 import (
+	"os"
 	"path/filepath"
-	"runtime"
 )
 
 // Path returns the absolute path to the given fixture.
 func Path(name string) string {
-	_, callerPath, _, ok := runtime.Caller(1)
-	if !ok {
-		panic("failed to get the caller's path")
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic("failed to obtain current working directory")
 	}
-	return filepath.Join(filepath.Dir(callerPath), "testdata", name)
+	return filepath.Join(cwd, "testdata", name)
 }


### PR DESCRIPTION
Previously, the path was determined using `runtime.Caller`. However, in some cases, `runtime.Caller` will not return an absolute file path. This, for example, happens when `-trimprefix` is passed as a compilation option which is used by many downstream distributions (e.g. [Alpine Linux](https://gitlab.alpinelinux.org/alpine/abuild/-/blob/3.13.0/default.conf?ref_type=tags#L5)) via `GOFLAGS`. Thereby causing test failures on such distributions.

This commit attempts to work around that by exploiting the fact that `go test` sets the working directory to the currently tested package source. Hence, allowing us to determine the fixture path relative to this directory, and thereby fixing test failures with `-trimprefix`.

I ran into this file creating a zk package for Alpine Linux: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/67271

Let me know if you have a better idea for resolving this and keep up the great work on zk! :)