### PR TITLE
Fix mix-up in error message when aborting

### DIFF
--- a/internal/adapter/editor/editor.go
+++ b/internal/adapter/editor/editor.go
@@ -3,6 +3,7 @@ package editor
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/kballard/go-shellquote"
@@ -43,5 +44,12 @@ func (e *Editor) Open(paths ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	return errors.Wrapf(cmd.Run(), "failed to launch editor: %s %s", e.editor, strings.Join(paths, " "))
+	err := cmd.Run()
+	switch err.(type) {
+	case *exec.ExitError:
+		return errors.Wrapf(err, "operation aborted by editor: %s %s", e.editor, strings.Join(paths, " "))
+	default:
+		return errors.Wrapf(err, "failed to launch editor: %s %s", e.editor, strings.Join(paths, " "))
+
+	}
 }


### PR DESCRIPTION
If I abort editing a file, `zk` shows 'failed to launch editor'. This message is not correct, since I explicitly aborted the operation after the editor successfully launched.

When using Vim, this is triggered by using `:cq`, which exits non-zero. With a GUI editor, this is usually achieved by pressing the Cancel/Abort button.

Update the error handling to show the correct error: if the editor executed and exited abnormally, indicate that the operation was aborted. Otherwise, show the previous message.