### PR TITLE
gh-pages build on push, not release

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,8 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,10 @@
 name: Deploy to GitHub Pages
 
 on:
-  release:
-    types:
-      - "published"
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
The gh pages fix from https://github.com/zk-org/zk/pull/387 setup deployment / build to occur on release publishing.

The documentation / readme is therefore stuck until the next zk semver release.

I think it's better to have the page rebuild on push / merge, as documentation updates are seemingly frequent.

@hugginsio what do you think?
