### PR TITLE
Expand tilde in config note.template

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -8,6 +8,7 @@ import (
 	toml "github.com/pelletier/go-toml"
 	"github.com/zk-org/zk/internal/util/errors"
 	"github.com/zk-org/zk/internal/util/opt"
+	"github.com/zk-org/zk/internal/util/paths"
 )
 
 // Config holds the user configuration.
@@ -312,7 +313,11 @@ func ParseConfig(content []byte, path string, parentConfig Config, isGlobal bool
 		config.Note.Extension = note.Extension
 	}
 	if note.Template != "" {
-		config.Note.BodyTemplatePath = opt.NewNotEmptyString(note.Template)
+		expanded, err := paths.ExpandTilde(note.Template)
+		if err != nil {
+			return config, wrap(err)
+		}
+		config.Note.BodyTemplatePath = opt.NewNotEmptyString(expanded)
 	}
 	if note.IDLength != 0 {
 		config.Note.IDOptions.Length = note.IDLength

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -201,7 +201,7 @@ const defaultConfig = `# zk configuration file
 #extension = "md"
 
 # Template used to generate a note's content.
-# If not an absolute path, it is relative to .zk/templates/
+# If not an absolute path or "~/path", it's relative to .zk/templates/
 template = "default.md"
 
 # Path globs ignored while indexing existing notes.
@@ -332,11 +332,11 @@ dead-link = "error"
 # Customize the completion pop-up of your LSP client.
 
 # Show the note title in the completion pop-up, or fallback on its path if empty.
-#note-label = "\{{title-or-path}}"
+#note-label = "{{title-or-path}}"
 # Filter out the completion pop-up using the note title or its path.
-#note-filter-text = "\{{title}} \{{path}}"
+#note-filter-text = "{{title}} {{path}}"
 # Show the note filename without extension as detail.
-#note-detail = "\{{filename-stem}}"
+#note-detail = "{{filename-stem}}"
 
 
 # NAMED FILTERS

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -201,7 +201,7 @@ const defaultConfig = `# zk configuration file
 #extension = "md"
 
 # Template used to generate a note's content.
-# If not an absolute path or "~/path", it's relative to .zk/templates/
+# If not an absolute path or "~/unix/path", it's relative to .zk/templates/
 template = "default.md"
 
 # Path globs ignored while indexing existing notes.
@@ -332,11 +332,11 @@ dead-link = "error"
 # Customize the completion pop-up of your LSP client.
 
 # Show the note title in the completion pop-up, or fallback on its path if empty.
-#note-label = "{{title-or-path}}"
+#note-label = "\{{title-or-path}}"
 # Filter out the completion pop-up using the note title or its path.
-#note-filter-text = "{{title}} {{path}}"
+#note-filter-text = "\{{title}} \{{path}}"
 # Show the note filename without extension as detail.
-#note-detail = "{{filename-stem}}"
+#note-detail = "\{{filename-stem}}"
 
 
 # NAMED FILTERS

--- a/internal/util/paths/paths.go
+++ b/internal/util/paths/paths.go
@@ -1,7 +1,9 @@
 package paths
 
 import (
+	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 	"time"
@@ -75,4 +77,19 @@ func WriteString(path string, content string) error {
 	defer f.Close()
 	_, err = f.WriteString(content)
 	return err
+}
+
+// Expands leading tilde.
+func ExpandTilde(path string) (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine current user")
+	}
+	home := usr.HomeDir
+	if path == "~" {
+		path = home
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(home, path[2:])
+	}
+	return path, nil
 }

--- a/tests/cmd-init-defaults.tesh
+++ b/tests/cmd-init-defaults.tesh
@@ -27,7 +27,7 @@ $ cat .zk/config.toml
 >#extension = "md"
 >
 ># Template used to generate a note's content.
-># If not an absolute path or "~/path", it's relative to .zk/templates/
+># If not an absolute path or "~/unix/path", it's relative to .zk/templates/
 >template = "default.md"
 >
 ># Path globs ignored while indexing existing notes.
@@ -142,11 +142,11 @@ $ cat .zk/config.toml
 ># Customize the completion pop-up of your LSP client.
 >
 ># Show the note title in the completion pop-up, or fallback on its path if empty.
->#note-label = ""
+>#note-label = "\{{title-or-path}}"
 ># Filter out the completion pop-up using the note title or its path.
->#note-filter-text = " "
+>#note-filter-text = "\{{title}} \{{path}}"
 ># Show the note filename without extension as detail.
->#note-detail = ""
+>#note-detail = "\{{filename-stem}}"
 >
 >
 ># NAMED FILTERS

--- a/tests/cmd-init-defaults.tesh
+++ b/tests/cmd-init-defaults.tesh
@@ -27,7 +27,7 @@ $ cat .zk/config.toml
 >#extension = "md"
 >
 ># Template used to generate a note's content.
-># If not an absolute path, it is relative to .zk/templates/
+># If not an absolute path or "~/path", it's relative to .zk/templates/
 >template = "default.md"
 >
 ># Path globs ignored while indexing existing notes.
@@ -142,11 +142,11 @@ $ cat .zk/config.toml
 ># Customize the completion pop-up of your LSP client.
 >
 ># Show the note title in the completion pop-up, or fallback on its path if empty.
->#note-label = "\{{title-or-path}}"
+>#note-label = ""
 ># Filter out the completion pop-up using the note title or its path.
->#note-filter-text = "\{{title}} \{{path}}"
+>#note-filter-text = " "
 ># Show the note filename without extension as detail.
->#note-detail = "\{{filename-stem}}"
+>#note-detail = ""
 >
 >
 ># NAMED FILTERS


### PR DESCRIPTION
This allows specifying paths relative to $HOME in the configuration file (this is particularly useful for the global config).

    [note]
    template = "~/.config/zk/default.md"