### PR TITLE
fix: lsp completion config defaults not rendering

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,8 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,9 +1,10 @@
 name: Deploy to GitHub Pages
 
 on:
-  release:
-    types:
-      - "published"
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	toml "github.com/pelletier/go-toml"
 	"github.com/zk-org/zk/internal/util/errors"
 	"github.com/zk-org/zk/internal/util/opt"
-	toml "github.com/pelletier/go-toml"
 )
 
 // Config holds the user configuration.
@@ -22,6 +22,10 @@ type Config struct {
 	Aliases  map[string]string
 	Extra    map[string]string
 }
+
+// NOTE: config generation occurs in core.Init. The below function is used
+// for test cases and as a program level default if the user conf is missing or
+// has values missing.
 
 // NewDefaultConfig creates a new Config with the default settings.
 func NewDefaultConfig() Config {
@@ -522,7 +526,7 @@ type tomlNoteConfig struct {
 	IDLength     int      `toml:"id-length"`
 	IDCase       string   `toml:"id-case"`
 	Exclude      []string `toml:"exclude"`
-	Ignore      []string `toml:"ignore"` // Legacy alias to `exclude`
+	Ignore       []string `toml:"ignore"` // Legacy alias to `exclude`
 }
 
 type tomlGroupConfig struct {

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -332,11 +332,11 @@ dead-link = "error"
 # Customize the completion pop-up of your LSP client.
 
 # Show the note title in the completion pop-up, or fallback on its path if empty.
-#note-label = "{{title-or-path}}"
+#note-label = "\{{title-or-path}}"
 # Filter out the completion pop-up using the note title or its path.
-#note-filter-text = "{{title}} {{path}}"
+#note-filter-text = "\{{title}} \{{path}}"
 # Show the note filename without extension as detail.
-#note-detail = "{{filename-stem}}"
+#note-detail = "\{{filename-stem}}"
 
 
 # NAMED FILTERS

--- a/internal/util/fixtures/fixtures.go
+++ b/internal/util/fixtures/fixtures.go
@@ -1,15 +1,15 @@
 package fixtures
 
 import (
+	"os"
 	"path/filepath"
-	"runtime"
 )
 
 // Path returns the absolute path to the given fixture.
 func Path(name string) string {
-	_, callerPath, _, ok := runtime.Caller(1)
-	if !ok {
-		panic("failed to get the caller's path")
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic("failed to obtain current working directory")
 	}
-	return filepath.Join(filepath.Dir(callerPath), "testdata", name)
+	return filepath.Join(cwd, "testdata", name)
 }


### PR DESCRIPTION
Resolves zk-org/zk#413

Braces for config options needed to be escaped.
