### PR TITLE
fix: default lsp config opts not being rendered

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	toml "github.com/pelletier/go-toml"
 	"github.com/zk-org/zk/internal/util/errors"
 	"github.com/zk-org/zk/internal/util/opt"
-	toml "github.com/pelletier/go-toml"
 )
 
 // Config holds the user configuration.
@@ -22,6 +22,10 @@ type Config struct {
 	Aliases  map[string]string
 	Extra    map[string]string
 }
+
+// NOTE: config generation occurs in core.Init. The below function is used
+// for test cases and as a program level default if the user conf is missing or
+// has values missing.
 
 // NewDefaultConfig creates a new Config with the default settings.
 func NewDefaultConfig() Config {
@@ -522,7 +526,7 @@ type tomlNoteConfig struct {
 	IDLength     int      `toml:"id-length"`
 	IDCase       string   `toml:"id-case"`
 	Exclude      []string `toml:"exclude"`
-	Ignore      []string `toml:"ignore"` // Legacy alias to `exclude`
+	Ignore       []string `toml:"ignore"` // Legacy alias to `exclude`
 }
 
 type tomlGroupConfig struct {

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -332,11 +332,11 @@ dead-link = "error"
 # Customize the completion pop-up of your LSP client.
 
 # Show the note title in the completion pop-up, or fallback on its path if empty.
-#note-label = "{{title-or-path}}"
+#note-label = "\{{title-or-path}}"
 # Filter out the completion pop-up using the note title or its path.
-#note-filter-text = "{{title}} {{path}}"
+#note-filter-text = "\{{title}} \{{path}}"
 # Show the note filename without extension as detail.
-#note-detail = "{{filename-stem}}"
+#note-detail = "\{{filename-stem}}"
 
 
 # NAMED FILTERS

--- a/tests/cmd-init-defaults.tesh
+++ b/tests/cmd-init-defaults.tesh
@@ -142,11 +142,11 @@ $ cat .zk/config.toml
 ># Customize the completion pop-up of your LSP client.
 >
 ># Show the note title in the completion pop-up, or fallback on its path if empty.
->#note-label = ""
+>#note-label = "\{{title-or-path}}"
 ># Filter out the completion pop-up using the note title or its path.
->#note-filter-text = " "
+>#note-filter-text = "\{{title}} \{{path}}"
 ># Show the note filename without extension as detail.
->#note-detail = ""
+>#note-detail = "\{{filename-stem}}"
 >
 >
 ># NAMED FILTERS


### PR DESCRIPTION
resolves zk-org/zk#413

Braces needed to be escaped.
Updated tesh test to reflect this fix (it was previously built on an output with this bug from zk-org/zk#413 present).

Unfortunately all changes got lumped into one commit message. Lost track of how that happened. Will fix in squash