### PR TITLE
refactor and tidy home / tilde expansion

### DIFF
--- a/internal/adapter/handlebars/handlebars.go
+++ b/internal/adapter/handlebars/handlebars.go
@@ -61,7 +61,6 @@ type LoaderOpts struct {
 }
 
 // NewLoader creates a new instance of Loader.
-//
 func NewLoader(opts LoaderOpts) *Loader {
 	return &Loader{
 		strings:     make(map[string]*Template),
@@ -129,6 +128,7 @@ func (l *Loader) locateTemplate(path string) (string, bool) {
 		return "", false
 	}
 
+    path = paths.ResolveHomeDir(path)
 	exists := func(path string) bool {
 		exists, err := paths.Exists(path)
 		return exists && err == nil

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/zk-org/zk/internal/adapter/editor"
 	"github.com/zk-org/zk/internal/adapter/fs"
@@ -74,18 +73,7 @@ func NewContainer(version string) (*Container, error) {
 
 	// Set the default notebook if not already set
 	// might be overrided if --notebook-dir flag is present
-	if osutil.GetOptEnv("ZK_NOTEBOOK_DIR").IsNull() && !config.Notebook.Dir.IsNull() {
-		// Expand in case there are environment variables on the path
-		notebookDir := os.Expand(config.Notebook.Dir.Unwrap(), os.Getenv)
-		if strings.HasPrefix(notebookDir, "~") {
-			dirname, err := os.UserHomeDir()
-			if err != nil {
-				return nil, wrap(err)
-			}
-			notebookDir = filepath.Join(dirname, notebookDir[1:])
-		}
-		os.Setenv("ZK_NOTEBOOK_DIR", notebookDir)
-	}
+	os.Setenv("ZK_NOTEBOOK_DIR", config.Notebook.Dir.Unwrap())
 
 	// Set the default shell if not already set
 	if osutil.GetOptEnv("ZK_SHELL").IsNull() && !config.Tool.Shell.IsEmpty() {

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -73,7 +73,10 @@ func NewContainer(version string) (*Container, error) {
 
 	// Set the default notebook if not already set
 	// might be overrided if --notebook-dir flag is present
-	os.Setenv("ZK_NOTEBOOK_DIR", config.Notebook.Dir.Unwrap())
+	if osutil.GetOptEnv("ZK_NOTEBOOK_DIR").IsNull() && !config.Notebook.Dir.IsNull() {
+		notebookDir := paths.ResolveHomeDir(config.Notebook.Dir.Unwrap())
+		os.Setenv("ZK_NOTEBOOK_DIR", notebookDir)
+	}
 
 	// Set the default shell if not already set
 	if osutil.GetOptEnv("ZK_SHELL").IsNull() && !config.Tool.Shell.IsEmpty() {

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -298,7 +298,8 @@ func ParseConfig(content []byte, path string, parentConfig Config, isGlobal bool
 	notebook := tomlConf.Notebook
 	if notebook.Dir != "" {
 		if isGlobal {
-			config.Notebook.Dir = opt.NewNotEmptyString(notebook.Dir)
+		    expanded := paths.ResolveHomeDir(notebook.Dir)
+			config.Notebook.Dir = opt.NewNotEmptyString(expanded)
 		} else {
 			return config, wrap(errors.New("notebook.dir should not be set on local configuration"))
 		}
@@ -313,10 +314,7 @@ func ParseConfig(content []byte, path string, parentConfig Config, isGlobal bool
 		config.Note.Extension = note.Extension
 	}
 	if note.Template != "" {
-		expanded, err := paths.ExpandTilde(note.Template)
-		if err != nil {
-			return config, wrap(err)
-		}
+		expanded := paths.ResolveHomeDir(note.Template)
 		config.Note.BodyTemplatePath = opt.NewNotEmptyString(expanded)
 	}
 	if note.IDLength != 0 {

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -265,7 +265,6 @@ func (c GroupConfig) Clone() GroupConfig {
 // in the given file.
 func OpenConfig(path string, parentConfig Config, fs FileStorage, isGlobal bool) (Config, error) {
 	// The local config is optional.
-    path = paths.ResolveHomeDir(path)
 	exists, err := fs.FileExists(path)
 	if err == nil && !exists {
 		return parentConfig, nil
@@ -299,7 +298,7 @@ func ParseConfig(content []byte, path string, parentConfig Config, isGlobal bool
 	notebook := tomlConf.Notebook
 	if notebook.Dir != "" {
 		if isGlobal {
-            config.Notebook.Dir = opt.NewNotEmptyString(notebook.Dir)
+			config.Notebook.Dir = opt.NewNotEmptyString(notebook.Dir)
 		} else {
 			return config, wrap(errors.New("notebook.dir should not be set on local configuration"))
 		}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -265,6 +265,7 @@ func (c GroupConfig) Clone() GroupConfig {
 // in the given file.
 func OpenConfig(path string, parentConfig Config, fs FileStorage, isGlobal bool) (Config, error) {
 	// The local config is optional.
+    path = paths.ResolveHomeDir(path)
 	exists, err := fs.FileExists(path)
 	if err == nil && !exists {
 		return parentConfig, nil
@@ -298,8 +299,7 @@ func ParseConfig(content []byte, path string, parentConfig Config, isGlobal bool
 	notebook := tomlConf.Notebook
 	if notebook.Dir != "" {
 		if isGlobal {
-		    expanded := paths.ResolveHomeDir(notebook.Dir)
-			config.Notebook.Dir = opt.NewNotEmptyString(expanded)
+            config.Notebook.Dir = opt.NewNotEmptyString(notebook.Dir)
 		} else {
 			return config, wrap(errors.New("notebook.dir should not be set on local configuration"))
 		}

--- a/internal/util/paths/paths.go
+++ b/internal/util/paths/paths.go
@@ -78,7 +78,7 @@ func WriteString(path string, content string) error {
 	return err
 }
 
-// Expands leading tilde.
+// Expands home directory to absolute path.
 func ResolveHomeDir(path string) string {
 
 	// Expand in case there are environment variables on the path
@@ -94,5 +94,6 @@ func ResolveHomeDir(path string) string {
 	} else if strings.HasPrefix(path, "~/") {
 		path = filepath.Join(home, path[2:])
 	}
+
 	return path
 }

--- a/internal/util/paths/paths.go
+++ b/internal/util/paths/paths.go
@@ -1,9 +1,8 @@
 package paths
 
 import (
-	"fmt"
+	"github.com/zk-org/zk/internal/util/errors"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"time"
@@ -80,16 +79,20 @@ func WriteString(path string, content string) error {
 }
 
 // Expands leading tilde.
-func ExpandTilde(path string) (string, error) {
-	usr, err := user.Current()
+func ResolveHomeDir(path string) string {
+
+	// Expand in case there are environment variables on the path
+	path = os.ExpandEnv(path)
+	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to determine current user")
+		errors.Wrap(err, "get user home directory")
+		return ""
 	}
-	home := usr.HomeDir
+
 	if path == "~" {
 		path = home
 	} else if strings.HasPrefix(path, "~/") {
 		path = filepath.Join(home, path[2:])
 	}
-	return path, nil
+	return path
 }


### PR DESCRIPTION
We added tilde expansion for note.template so users can share template files between notebooks in #431.

We however overlooked that tilde / home dir expansion was already being implemented in isolation for the global notebook directory in `container.go`.

I've refactored that code into the function @Hugo created, and also made a few optimisations to it (and renamed it as it now expands more than just tildes).

I made a decision to not pass up the `err` from `ResolveHomeDir()` and wrap it instead, as there is only one error that would be passed up, so it makes each call to it unnecessarily verbose? Very open and interested to know if that's not the best idea.

Otherwise, am I overlooking anything, have I overdone / underdone anything, or is it looking alright?
