### PR TITLE
Update link to neuron docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ video, [_Note-taking System ALL Programmers Should Consider_](https://www.youtub
 ### What `zk` is not
 
 * A note editor.
-* A tool to serve your notes on the web – for this, you may be interested in [Neuron](docs/neuron.md) or [Gollum](https://github.com/gollum/gollum).
+* A tool to serve your notes on the web – for this, you may be interested in [Neuron](docs/tips/neuron.md) or [Gollum](https://github.com/gollum/gollum).
 
 ## Install
 


### PR DESCRIPTION
This link looks like it has been updated in https://github.com/zk-org/zk/pull/453.