### PR TITLE
Rename 'ignore' to 'exclude' in default config

### DIFF
--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -204,10 +204,10 @@ const defaultConfig = `# zk configuration file
 # If not an absolute path or "~/unix/path", it's relative to .zk/templates/
 template = "default.md"
 
-# Path globs excluded while indexing existing notes.
+# Path globs ignored while indexing existing notes.
 #exclude = [
 #    "drafts/*",
-#	"log.md"
+#    "log.md"
 #]
 
 # Configure random ID generation.

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -204,8 +204,8 @@ const defaultConfig = `# zk configuration file
 # If not an absolute path or "~/unix/path", it's relative to .zk/templates/
 template = "default.md"
 
-# Path globs ignored while indexing existing notes.
-#ignore = [
+# Path globs excluded while indexing existing notes.
+#exclude = [
 #    "drafts/*",
 #	"log.md"
 #]

--- a/tests/cmd-init-defaults.tesh
+++ b/tests/cmd-init-defaults.tesh
@@ -31,9 +31,9 @@ $ cat .zk/config.toml
 >template = "default.md"
 >
 ># Path globs ignored while indexing existing notes.
->#ignore = [
+>#exclude = [
 >#    "drafts/*",
->#	"log.md"
+>#    "log.md"
 >#]
 >
 ># Configure random ID generation.


### PR DESCRIPTION
New notebooks (`zk init`) use the legacy `ignore` config parameter which does not work anymore.

I believe this was one missed in #322 