### PR TITLE
Resolve symlinks when comparing notebook paths

### DIFF
--- a/internal/adapter/fs/fs.go
+++ b/internal/adapter/fs/fs.go
@@ -134,3 +134,7 @@ func (fs *FileStorage) Write(path string, content []byte) error {
 	_, err = f.Write(content)
 	return err
 }
+
+func (fs *FileStorage) EvalSymlinks(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}

--- a/internal/core/fs.go
+++ b/internal/core/fs.go
@@ -24,8 +24,8 @@ type FileStorage interface {
 	// DirExists returns whether a directory exists at the given file path.
 	DirExists(path string) (bool, error)
 
-  // EvalSymlinks returns the real path of a given symlink.
-  EvalSymlinks(path string) (string, error)
+	// EvalSymlinks returns the real path of a given symlink.
+	EvalSymlinks(path string) (string, error)
 
 	// IsDescendantOf returns whether the given path is dir or one of its descendants.
 	IsDescendantOf(dir string, path string) (bool, error)

--- a/internal/core/fs.go
+++ b/internal/core/fs.go
@@ -24,6 +24,9 @@ type FileStorage interface {
 	// DirExists returns whether a directory exists at the given file path.
 	DirExists(path string) (bool, error)
 
+  // EvalSymlinks returns the real path of a given symlink.
+  EvalSymlinks(path string) (string, error)
+
 	// IsDescendantOf returns whether the given path is dir or one of its descendants.
 	IsDescendantOf(dir string, path string) (bool, error)
 

--- a/internal/core/fs_test.go
+++ b/internal/core/fs_test.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"os"
-  "fmt"
+	"fmt"
 	"path/filepath"
 )
 

--- a/internal/core/fs_test.go
+++ b/internal/core/fs_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"os"
+  "fmt"
 	"path/filepath"
 )
 
@@ -60,6 +61,22 @@ func (fs *fileStorageMock) DirExists(path string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func (fs *fileStorageMock) EvalSymlinks(path string) (string, error) {
+	// For mock filesystem, we should check if the directory exists in our dirs slice
+	for _, dir := range fs.dirs {
+		if dir == path {
+			return path, nil
+		}
+	}
+  
+	// Check if it's a file in our files map
+	if _, ok := fs.files[path]; ok {
+		return path, nil
+	}
+
+	return "", fmt.Errorf("lstat %s: no such file or directory", path)
 }
 
 func (fs *fileStorageMock) fileInfo(path string) (*os.FileInfo, error) {


### PR DESCRIPTION
Hi, first of all, thanks for `zk`! I'm just getting started with it, setting things up.

I encountered a very small problem: As I share the same linux config and sync files between two computers, I have `~/Sync` which is a symlink pointing to different paths on both.

As an example, my config defines `ZK_NOTEBOOK_DIR=/home/clementpoiret/Sync/Notes/zk`, which is itself a symlink to `/mnt/hdd/Sync/Notes/zk`. Using the command `zk new --no-input ($env.ZK_NOTEBOOK_DIR ++ "fleeting") --title "Test"` (some nushell syntax here, sorry for that), give the following error:

```
zk: error: new note: /home/clementpoiret/Sync/Notes/zk/fleeting: path is outside the notebook at /mnt/hdd/Sync/Notes/zk
```

Therefore, I propose to [resolve symlinks](https://pkg.go.dev/github.com/moby/sys/symlink) in the `RelPath` function. I hope you'll be okay with that!

Sincerely,
Clément