### PR TITLE
fix test. Set current day one month in advance

### DIFF
--- a/internal/adapter/handlebars/handlebars_test.go
+++ b/internal/adapter/handlebars/handlebars_test.go
@@ -242,7 +242,9 @@ func TestFormatDateHelper(t *testing.T) {
 
 func TestFormatDateHelperElapsedYear(t *testing.T) {
 	year := time.Now().UTC().Year() - 14
-	context := map[string]interface{}{"now": time.Date(year, 11, 17, 20, 34, 58, 651387237, time.UTC)}
+	month := time.Now().UTC().Month() + 1
+	day := time.Now().UTC().Day()
+	context := map[string]interface{}{"now": time.Date(year, month, day, 20, 34, 58, 651387237, time.UTC)}
 	testString(t, "{{format-date now 'elapsed'}}", context, "14 years ago")
 }
 


### PR DESCRIPTION
go normalises the dates, so there shouldn't be an issue when arbitrarily adding +1 to a month (where at some point the test may be ran on Feb 30th, which would just become March 1st)