### PR TITLE
Fix error text when no notes found.

### DIFF
--- a/internal/cli/cmd/edit.go
+++ b/internal/cli/cmd/edit.go
@@ -72,7 +72,7 @@ func (cmd *Edit) Run(container *cli.Container) error {
 		return editor.Open(paths...)
 
 	} else {
-		fmt.Fprintln(os.Stderr, "Found 0 note")
+		fmt.Fprintln(os.Stderr, "Found 0 notes.")
 		return nil
 	}
 }


### PR DESCRIPTION
The error message read "Found 0 note". This patch corrects it to "Found 0 notes.".