### PR TITLE
Fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        If you have an idea, _please [open as a discussion](https://github.com/zk-org/zk/discussions/new?category=ideas)_ instead of an issue. This helps keep the issue tracker more relavent.
+        If you have an idea, _please [open as a discussion](https://github.com/zk-org/zk/discussions/new?category=ideas)_ instead of an issue. This helps keep the issue tracker more relevant.
         Be aware that feature requests [may not get much attention through 2025!](https://github.com/zk-org/zk/discussions/486)
   - type: textarea
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 
 * Fixed parsing large notes @khimaros in https://github.com/zk-org/zk/pull/339
 * fix day range parsing (zk-org/zk#382) by @tjex in https://github.com/zk-org/zk/pull/384
-* accept tripple dash file URIs as valid links by @tjex in https://github.com/zk-org/zk/pull/391
+* accept triple dash file URIs as valid links by @tjex in https://github.com/zk-org/zk/pull/391
 * fix(lsp): fix trigger completion of zk LSP by @Rahlir in https://github.com/zk-org/zk/pull/397
 * fix(lsp): ignore diagnostic check within code blocks by @Rahlir in https://github.com/zk-org/zk/pull/399
 * allow notebook as hidden dir by @tjex in https://github.com/zk-org/zk/pull/402

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ created.
 
 - `.github/workflows/build.yml` checks that the project can be built and the tests still
   pass.
-- `.github/workflows/build-binaries.yml` builds zk binaries for all platforms and uplaods
+- `.github/workflows/build-binaries.yml` builds zk binaries for all platforms and uploads
   artifacts.
 - `.github/workflows/codeql.yml` runs static analysis to vet code quality.
 - `.github/workflows/gh-pages.yml` deploy the documentation files to GitHub Pages.

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ define go
 endef
 
 # Alpine (musl) requires statically linked libs. This should be compatible for
-# Void linux and other musl based distros aswell.
+# Void linux and other musl based distros as well.
 define alpine
 	$(ENV_PREFIX) go $(1) -tags "fts5" -ldflags "-extldflags=-static -X=main.Version=$(VERSION) -X=main.Build=$(BUILD)" $(2)
 endef

--- a/docs/notes/note-frontmatter.md
+++ b/docs/notes/note-frontmatter.md
@@ -3,7 +3,7 @@
 Markdown being a simple format, it does not offer any way to attach additional
 metadata to a note. The community came up with a solution by inserting a YAML
 header at the top of each note to contain its metadata. This method is widely
-supported among Zettelkasten softwares, including `zk`.
+supported among Zettelkasten software, including `zk`.
 
 ```yaml
 ---

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -304,7 +304,7 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 				continue
 			}
 
-			// ignore tripple dash file URIs [title](file:///foo.go) and magnet links
+			// ignore triple dash file URIs [title](file:///foo.go) and magnet links
 			if match[5]-match[4] >= 8 {
 				linkURL := line[match[4]:match[5]]
 				fileURIresult := linkURL[:8]

--- a/internal/adapter/markdown/markdown_test.go
+++ b/internal/adapter/markdown/markdown_test.go
@@ -181,7 +181,7 @@ func TestParseHashtags(t *testing.T) {
 	// Authorized special characters
 	test("#a/@'~-_$%&+=: end", []string{"a/@'~-_$%&+=:"})
 	// Escape punctuation and space
-	test(`#an\ \\espaced\ tag\!`, []string{`an \espaced tag!`})
+	test(`#an\ \\escaped\ tag\!`, []string{`an \escaped tag!`})
 	// Hashtags containing only numbers and dots are invalid
 	test("#123, #1.2.3", []string{})
 	// Must not be preceded by a hash or any other valid hashtag character
@@ -221,7 +221,7 @@ func TestParseWordtags(t *testing.T) {
 	// Authorized special characters
 	test("#a/@'~-_$%&+=: end", []string{"a/@'~-_$%&+=:"})
 	// Escape punctuation and space
-	test(`#an\ \\espaced\ tag\!`, []string{`an \espaced tag!`})
+	test(`#an\ \\escaped\ tag\!`, []string{`an \escaped tag!`})
 	// Leading and trailing spaces are trimmed
 	test(`#\ \	tag\	\   end`, []string{`tag`})
 	// Hashtags containing only numbers and dots are invalid
@@ -271,7 +271,7 @@ func TestParseColontags(t *testing.T) {
 	// Authorized special characters
 	test(":#a/@'~-_$%&+=: end", []string{"#a/@'~-_$%&+="})
 	// Escape punctuation and space
-	test(`:an\ \\espaced\ tag\!:`, []string{`an \espaced tag!`})
+	test(`:an\ \\escaped\ tag\!:`, []string{`an \escaped tag!`})
 	// Leading and trailing spaces are trimmed
 	test(`:\ \	tag\	\ :`, []string{`tag`})
 	// A colontag containing only numbers is valid

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -72,7 +72,7 @@ func NewContainer(version string) (*Container, error) {
 	}
 
 	// Set the default notebook if not already set
-	// might be overrided if --notebook-dir flag is present
+	// might be overridden if --notebook-dir flag is present
 	if osutil.GetOptEnv("ZK_NOTEBOOK_DIR").IsNull() && !config.Notebook.Dir.IsNull() {
 		notebookDir, err := paths.ExpandPath(config.Notebook.Dir.Unwrap())
 		if err != nil {

--- a/internal/cli/filtering_test.go
+++ b/internal/cli/filtering_test.go
@@ -103,7 +103,7 @@ func TestExpandNamedFiltersJoinBools(t *testing.T) {
 }
 
 // ExpandNamedFilters: non-zero integer and non-empty string options take precedence over named filters.
-func TestExpandNamedFiltersJoinLitterals(t *testing.T) {
+func TestExpandNamedFiltersJoinLiterals(t *testing.T) {
 	f1 := Filtering{Path: []string{"f1", "f2"}}
 	res1, err := f1.ExpandNamedFilters(
 		map[string]string{

--- a/tests/cmd-list-filter-match-exact.tesh
+++ b/tests/cmd-list-filter-match-exact.tesh
@@ -16,7 +16,7 @@ $ zk list -q --debug-style -Me --match '["न", "म", "स्", "ते"]'
 >  - Given the Hindi word "नमस्ते":
 >
 
-# Mutliple match flags.
+# Multiple match flags.
 $ zk list -q --debug-style -Me --match "thread" --match "mut"
 ><title>Concurrency in Rust</title> <path>g7qa.md</path> (just now)
 >
@@ -35,7 +35,7 @@ $ zk list -q --debug-style -Me --match "thread" --match "mut"
 >        *   Thanks to its [Ownership](../88el) pattern, Rust makes sure we can't mess up when using locks.
 >
 
-# Mutliple match flags.
+# Multiple match flags.
 $ zk list -q --debug-style -Me --match "thread" --match "mutual"
 ><title>Mutex</title> <path>inbox/er4k.md</path> (just now)
 >

--- a/tests/cmd-new.tesh
+++ b/tests/cmd-new.tesh
@@ -66,13 +66,13 @@ $ EDITOR="echo 'edit'" zk new --title "Edit"
 $ EDITOR="echo 'edit'" zk new --title "Print path" --print-path
 >{{working-dir}}/print-path.md
 
-# Set explicitely today's date (natural dates).
+# Set explicitly today's date (natural dates).
 $ zk new --group date --date "January 2nd" --dry-run
 2>{{working-dir}}/02-01.md
 $ zk new --group date --date "December 24th" --dry-run
 2>{{working-dir}}/24-12.md
 
-# Set explicitely today's date (RFC 3339)
+# Set explicitly today's date (RFC 3339)
 $ zk new --group date-raw --date "2022-01-23T13:55:48+01:00" --dry-run
 2>{{working-dir}}/2022-01-23 13:55:48 +0100 {{match ".+"}}.md
 $ zk new --group date-raw --date "2022-02-17T17:53:12" --dry-run

--- a/tests/fixtures/full-sample/uok6.md
+++ b/tests/fixtures/full-sample/uok6.md
@@ -2,7 +2,7 @@
 
 Choose a portfolio strategy, such as the [Couch potato investment strategy](hdi6), and stick to it.
 
-Second-guessing and tweaking make your portfolio under perform. Ignore your emotions when the market fluctuates, this derails most investors. Instead, keep steady and trust that [compound interests make you rich](smdc). A good way to do that is to look at your investments performance only once a year.
+Second-guessing and tweaking make your portfolio under perform. Ignore your emotions when the market fluctuates, this details most investors. Instead, keep steady and trust that [compound interests make you rich](smdc). A good way to do that is to look at your investments performance only once a year.
 
 ## The less you think about the market, the more money you make
 


### PR DESCRIPTION
Found via `codespell -S *.svg -L titel,potatoe` and `typos --hidden --format brief`