### PR TITLE
Fix LSP Crash in Code Fences

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
     attributes:
       value: |
         If you have an idea, _please [open as a discussion](https://github.com/zk-org/zk/discussions/new?category=ideas)_ instead of an issue. This helps keep the issue tracker more relavent.
-        Be aware that feature requests [may not get much attention through 2025!](https://github.com/zk-org/zk/discussions/486).
+        Be aware that feature requests [may not get much attention through 2025!](https://github.com/zk-org/zk/discussions/486)
   - type: textarea
     attributes:
       label: Exception

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -216,16 +216,23 @@ var currentCodeBlockStart = -1
 // check whether the current line in document is within a fenced or indented
 // code block
 func isLineWithinCodeBlock(lines []string, lineIndex int, line string) bool {
-	if len(line) == 0 { // if 0 either it's in a fence or no
+	if len(line) == 0 {
 		return insideFenced
+	}
+	isEndOfFence := func(line string) bool {
+		if !insideFenced ||
+			currentCodeBlockStart < 0 ||
+			len(line) < 3 ||
+			len(lines) <= currentCodeBlockStart ||
+			len(lines[currentCodeBlockStart]) < 3 ||
+			fencedEndRegex.FindStringIndex(line) == nil {
+			return false
+		}
+		return lines[currentCodeBlockStart][:3] == line[:3]
 	}
 	// if line is already within code fences or indented code block
 	if insideFenced && currentCodeBlockStart > -1 {
-		if fencedEndRegex.FindStringIndex(line) != nil &&
-			currentCodeBlockStart < len(lines) &&
-			3 <= len(lines[currentCodeBlockStart]) &&
-			3 <= len(line) &&
-			lines[currentCodeBlockStart][:3] == line[:3] {
+		if isEndOfFence(line) {
 			// Fenced code block ends with this line
 			insideFenced = false
 			currentCodeBlockStart = -1

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -216,9 +216,14 @@ var currentCodeBlockStart = -1
 // check whether the current line in document is within a fenced or indented
 // code block
 func isLineWithinCodeBlock(lines []string, lineIndex int, line string) bool {
+	if len(line) == 0 { // if 0 either it's in a fence or no
+		return insideFenced
+	}
 	// if line is already within code fences or indented code block
 	if insideFenced && currentCodeBlockStart > -1 {
 		if fencedEndRegex.FindStringIndex(line) != nil &&
+			currentCodeBlockStart < len(lines) &&
+			3 <= len(line) &&
 			lines[currentCodeBlockStart][:3] == line[:3] {
 			// Fenced code block ends with this line
 			insideFenced = false
@@ -258,15 +263,6 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 
 	lines := d.GetLines()
 	for lineIndex, line := range lines {
-
-		// Cannot be link with less than 4 chars.
-		if len(line) < 4 {
-			// This then beefs up the global vars, because it doesn't call isLinWithinCodeBlock all of the time...
-			if line == "```" {
-				insideFenced = !insideFenced
-			}
-			continue
-		}
 
 		if isLineWithinCodeBlock(lines, lineIndex, line) {
 			continue

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -213,10 +213,10 @@ var insideFenced = false
 var insideIndented = false
 var currentCodeBlockStart = -1
 
-// check whether the current line in document is within a fenced or indented 
+// check whether the current line in document is within a fenced or indented
 // code block
 func isLineWithinCodeBlock(lines []string, lineIndex int, line string) bool {
-    // if line is already within code fences or indented code block
+	// if line is already within code fences or indented code block
 	if insideFenced {
 		if fencedEndRegex.FindStringIndex(line) != nil &&
 			lines[currentCodeBlockStart][:3] == line[:3] {
@@ -258,6 +258,15 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 
 	lines := d.GetLines()
 	for lineIndex, line := range lines {
+
+		// Cannot be link with less than 4 chars.
+		if len(line) < 4 {
+			// This then beefs up the global vars, because it doesn't call isLinWithinCodeBlock all of the time...
+			if line == "```" {
+				insideFenced = !insideFenced
+			}
+			continue
+		}
 
 		if isLineWithinCodeBlock(lines, lineIndex, line) {
 			continue

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -223,6 +223,7 @@ func isLineWithinCodeBlock(lines []string, lineIndex int, line string) bool {
 	if insideFenced && currentCodeBlockStart > -1 {
 		if fencedEndRegex.FindStringIndex(line) != nil &&
 			currentCodeBlockStart < len(lines) &&
+			3 <= len(lines[currentCodeBlockStart]) &&
 			3 <= len(line) &&
 			lines[currentCodeBlockStart][:3] == line[:3] {
 			// Fenced code block ends with this line

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -217,7 +217,7 @@ var currentCodeBlockStart = -1
 // code block
 func isLineWithinCodeBlock(lines []string, lineIndex int, line string) bool {
 	// if line is already within code fences or indented code block
-	if insideFenced {
+	if insideFenced && currentCodeBlockStart > -1 {
 		if fencedEndRegex.FindStringIndex(line) != nil &&
 			lines[currentCodeBlockStart][:3] == line[:3] {
 			// Fenced code block ends with this line

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -216,15 +216,15 @@ var currentCodeBlockStart = -1
 // check whether the current line in document is within a fenced or indented
 // code block
 func isLineWithinCodeBlock(lines []string, lineIndex int, line string) bool {
-	// if line is already within code fences or indented code block
+	// Reset global state from previous runs
 	if lineIndex == 0 {
 		insideInline = false
 		insideFenced = false
 		insideIndented = false
 		currentCodeBlockStart = -1
-		return false
 	}
 
+	// if line is already within code fences or indented code block
 	if insideFenced {
 		if fencedEndRegex.FindStringIndex(line) != nil &&
 			lines[currentCodeBlockStart][:3] == line[:3] {


### PR DESCRIPTION
## Description
This PR fixes the crash described in #461.

The root cause of the problem was that the global state that tracks whether or not a line is in a code fence was not reset after each pass over the file. This behavior can be shown in the `test-wrap.md` file.

This would cause the `currentCodeBlockStart` to not always point to the fence.
Sometimes it would point to a line with len < 3, which resulted in a out of bounds read in `lines[currentCodeBlockStart][:3] == line[:3]`.

Another undefined state caused by this is where `lineIndex` < `currentCodeBlockStart`.

## Testing:

I manually tested by attaching the lsp to `nvim 0v0.10.4` on the following files:
[test-note.md](https://github.com/user-attachments/files/18490023/test-note.md)
[test-fence.md](https://github.com/user-attachments/files/18924318/test-fence.md)
[test-wrap.md](https://github.com/user-attachments/files/18924540/test-wrap.md)
