### PR TITLE
fix: nested group rules

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -113,8 +113,8 @@ func (c Config) GroupConfigNamed(name string) (GroupConfig, error) {
 // GroupNameForPath returns the name of the GroupConfig matching the given
 // path, relative to the notebook.
 func (c Config) GroupNameForPath(path string) (string, error) {
-    var longestMatch string
-    var matchedName string
+	var longestMatch string
+	var matchedName string
 
 	for name, config := range c.Groups {
 		for _, groupPath := range config.Paths {
@@ -122,16 +122,16 @@ func (c Config) GroupNameForPath(path string) (string, error) {
 			if err != nil {
 				return "", errors.Wrapf(err, "failed to match group %s to %s", name, path)
 			} else if matches {
-                // Early return if an exact match
+				// Early return if an exact match
 				return name, nil
 			}
-            if strings.HasPrefix(path, groupPath+"/") {
-                // If the match is partial, find the longest prefix overlap
-                if len(groupPath) > len(longestMatch) {
-                    longestMatch = groupPath
-                    matchedName = name
-                }
-            }
+			if strings.HasPrefix(path, groupPath+"/") {
+				// If the match is partial, find the longest prefix overlap
+				if len(groupPath) > len(longestMatch) {
+					longestMatch = groupPath
+					matchedName = name
+				}
+			}
 		}
 	}
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -113,21 +113,29 @@ func (c Config) GroupConfigNamed(name string) (GroupConfig, error) {
 // GroupNameForPath returns the name of the GroupConfig matching the given
 // path, relative to the notebook.
 func (c Config) GroupNameForPath(path string) (string, error) {
+    var longestMatch string
+    var matchedName string
+
 	for name, config := range c.Groups {
 		for _, groupPath := range config.Paths {
 			matches, err := filepath.Match(groupPath, path)
 			if err != nil {
 				return "", errors.Wrapf(err, "failed to match group %s to %s", name, path)
 			} else if matches {
+                // Early return if an exact match
 				return name, nil
 			}
-			if strings.HasPrefix(path, groupPath+"/") {
-				return name, nil
-			}
+            if strings.HasPrefix(path, groupPath+"/") {
+                // If the match is partial, find the longest prefix overlap
+                if len(groupPath) > len(longestMatch) {
+                    longestMatch = groupPath
+                    matchedName = name
+                }
+            }
 		}
 	}
 
-	return "", nil
+	return matchedName, nil
 }
 
 // FormatConfig holds the configuration for document formats, such as Markdown.

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -275,14 +275,14 @@ func TestParseComplete(t *testing.T) {
 	})
 }
 
-func TestGroupNameForPathPrefersLongestMatch(t *testing.T) {
+func TestGroupNameForPathApplyDeepestMatch(t *testing.T) {
 	config := Config{
 		Groups: map[string]GroupConfig{
 			"parent": {
-				Paths: []string{"area"},
+				Paths: []string{"dir1"},
 			},
 			"child": {
-				Paths: []string{"area/subfolder"},
+				Paths: []string{"dir1/dir2"},
 			},
 			"other": {
 				Paths: []string{"other"},
@@ -290,11 +290,11 @@ func TestGroupNameForPathPrefersLongestMatch(t *testing.T) {
 		},
 	}
 
-	name, err := config.GroupNameForPath("area/subfolder/note.md")
+	name, err := config.GroupNameForPath("dir1/dir2/note.md")
 	assert.Nil(t, err)
 	assert.Equal(t, name, "child")
 
-	name, err = config.GroupNameForPath("area/note.md")
+	name, err = config.GroupNameForPath("dir1/note.md")
 	assert.Nil(t, err)
 	assert.Equal(t, name, "parent")
 

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -275,6 +275,34 @@ func TestParseComplete(t *testing.T) {
 	})
 }
 
+func TestGroupNameForPathPrefersLongestMatch(t *testing.T) {
+    config := Config{
+        Groups: map[string]GroupConfig{
+            "parent": {
+                Paths: []string{"area"},
+            },
+            "child": {
+                Paths: []string{"area/subfolder"},
+            },
+            "other": {
+                Paths: []string{"other"},
+            },
+        },
+    }
+
+    name, err := config.GroupNameForPath("area/subfolder/note.md")
+    assert.Nil(t, err)
+    assert.Equal(t, name, "child")
+
+    name, err = config.GroupNameForPath("area/note.md")
+    assert.Nil(t, err)
+    assert.Equal(t, name, "parent")
+
+    name, err = config.GroupNameForPath("other/note.md")
+    assert.Nil(t, err)
+    assert.Equal(t, name, "other")
+}
+
 func TestParseMergesGroupConfig(t *testing.T) {
 	conf, err := ParseConfig([]byte(`
 		[note]

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -276,31 +276,31 @@ func TestParseComplete(t *testing.T) {
 }
 
 func TestGroupNameForPathPrefersLongestMatch(t *testing.T) {
-    config := Config{
-        Groups: map[string]GroupConfig{
-            "parent": {
-                Paths: []string{"area"},
-            },
-            "child": {
-                Paths: []string{"area/subfolder"},
-            },
-            "other": {
-                Paths: []string{"other"},
-            },
-        },
-    }
+	config := Config{
+		Groups: map[string]GroupConfig{
+			"parent": {
+				Paths: []string{"area"},
+			},
+			"child": {
+				Paths: []string{"area/subfolder"},
+			},
+			"other": {
+				Paths: []string{"other"},
+			},
+		},
+	}
 
-    name, err := config.GroupNameForPath("area/subfolder/note.md")
-    assert.Nil(t, err)
-    assert.Equal(t, name, "child")
+	name, err := config.GroupNameForPath("area/subfolder/note.md")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "child")
 
-    name, err = config.GroupNameForPath("area/note.md")
-    assert.Nil(t, err)
-    assert.Equal(t, name, "parent")
+	name, err = config.GroupNameForPath("area/note.md")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "parent")
 
-    name, err = config.GroupNameForPath("other/note.md")
-    assert.Nil(t, err)
-    assert.Equal(t, name, "other")
+	name, err = config.GroupNameForPath("other/note.md")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "other")
 }
 
 func TestParseMergesGroupConfig(t *testing.T) {

--- a/tests/fixtures/issue-490/.zk/config.toml
+++ b/tests/fixtures/issue-490/.zk/config.toml
@@ -1,0 +1,16 @@
+[note]
+filename = "{{slug title}}"
+
+[group.area]
+paths = ["area"]
+
+[group.area.note]
+extension = "md"
+template = "template1.md"
+
+[group.subarea]
+paths = ["area/subfolder"]
+
+[group.subarea.note]
+extension = "md"
+template = "template2.md"

--- a/tests/fixtures/issue-490/.zk/config.toml
+++ b/tests/fixtures/issue-490/.zk/config.toml
@@ -1,16 +1,18 @@
 [note]
-filename = "{{slug title}}"
+filename = "untitled"
 
-[group.area]
-paths = ["area"]
+[group.t1]
+paths = ["dir1", "dir1/dir2/dir3"]
 
-[group.area.note]
+[group.t1.note]
 extension = "md"
 template = "template1.md"
 
-[group.subarea]
-paths = ["area/subfolder"]
 
-[group.subarea.note]
+# This group sits between the two directories of t1.
+[group.t2]
+paths = ["dir1/dir2"]
+
+[group.t2.note]
 extension = "md"
 template = "template2.md"

--- a/tests/fixtures/issue-490/.zk/templates/template1.md
+++ b/tests/fixtures/issue-490/.zk/templates/template1.md
@@ -1,0 +1,1 @@
+Template 1

--- a/tests/fixtures/issue-490/.zk/templates/template2.md
+++ b/tests/fixtures/issue-490/.zk/templates/template2.md
@@ -1,0 +1,1 @@
+Template 2

--- a/tests/issue-490.tesh
+++ b/tests/issue-490.tesh
@@ -1,0 +1,16 @@
+$ cd issue-490
+
+# Test that subfolder path takes precedence over parent path
+$ zk new area/subfolder --title "TestNote" --dry-run
+>Template 2
+2>{{working-dir}}/area/subfolder/testnote.md
+
+# Test that parent path still works for direct children
+$ zk new area --title "ParentNote" --dry-run
+>Template 1
+2>{{working-dir}}/area/parentnote.md
+
+# Test that explicit group override still works
+$ zk new area/subfolder --group area --title "OverrideTest" --dry-run
+>Template 1
+2>{{working-dir}}/area/subfolder/overridetest.md

--- a/tests/issue-490.tesh
+++ b/tests/issue-490.tesh
@@ -1,16 +1,25 @@
 $ cd issue-490
 
-# Test that subfolder path takes precedence over parent path
-$ zk new area/subfolder --title "TestNote" --dry-run
->Template 2
-2>{{working-dir}}/area/subfolder/testnote.md
+# This test ensures that group rules do not override other group
+# rules that are applied to child directories.
 
-# Test that parent path still works for direct children
-$ zk new area --title "ParentNote" --dry-run
+# Test that group t1 rules are followed.
+$ zk new dir1 --dry-run
 >Template 1
-2>{{working-dir}}/area/parentnote.md
+2>{{working-dir}}/dir1/untitled.md
+
+# Test that group t1 rules are followed.
+$ zk new dir1/dir2/dir3 --dry-run
+>Template 1
+2>{{working-dir}}/dir1/dir2/dir3/untitled.md
+
+# Test that group t2 rules are followed, signifying that nested group rules are
+# functioning correctly.
+$ zk new dir1/dir2 --dry-run
+>Template 2
+2>{{working-dir}}/dir1/dir2/untitled.md
 
 # Test that explicit group override still works
-$ zk new area/subfolder --group area --title "OverrideTest" --dry-run
+$ zk new dir1/dir2 --group t1 --dry-run
 >Template 1
-2>{{working-dir}}/area/subfolder/overridetest.md
+2>{{working-dir}}/dir1/dir2/untitled.md


### PR DESCRIPTION
An attempt to fix the bug described in https://github.com/zk-org/zk/issues/490

The bug was due to early returning when a partial prefix match happened.
We now find the longest partial prefix match and return that instead.
