### PR TITLE
static site title and version clarification

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,4 +29,4 @@ master_doc = "index"
 html_theme = "furo"
 html_title = "zk : a plain text note-taking assitant"
 # html_static_path = ["_static"]
-templates_path = ["_templates"]
+# templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,8 @@ exclude_patterns = [".zk"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "furo"
-# html_static_path = ["_static"]
 master_doc = "index"
+html_theme = "furo"
+html_title = "zk : a plain text note-taking assitant"
+# html_static_path = ["_static"]
+templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,8 @@
 
 Install as below and then... :doc:`get zettling <tips/getting-started>`!
 
+This site always represents the latest state of the documentation.
+
 Installation
 ============
 


### PR DESCRIPTION
Having the version number in the title is not great for search engines. Old versions will be indexed and cause confusion.

I've opted for removing the version number completely as the docs site can also have changes that are ahead of the latest public version.

Until we implement proper version tracking on the site like [here](https://olgarithms.github.io/sphinx-tutorial/docs/9-versioning.html) I'm opting to leave the version out completely. 

It causes more confusion than good.