### PR TITLE
ci: set gh-pages workflow to run on ubuntu-latest

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,3 +30,4 @@ html_theme = "furo"
 html_title = "zk : a plain text note-taking assitant"
 # html_static_path = ["_static"]
 # templates_path = ["_templates"]
+


### PR DESCRIPTION
ubuntu-20 will soon be completely removed from support and will fail on runs.