### PR TITLE
Fix LSP error message

### DIFF
--- a/internal/adapter/lsp/cmd_list.go
+++ b/internal/adapter/lsp/cmd_list.go
@@ -24,18 +24,18 @@ func executeCommandList(logger util.Logger, notebook *core.Notebook, args []inte
 	if len(args) > 1 {
 		arg, ok := args[1].(map[string]interface{})
 		if !ok {
-			return nil, fmt.Errorf("%s expects a dictionary of options as second argument, got: %v", cmdTagList, args[1])
+			return nil, fmt.Errorf("%s expects a dictionary of options as second argument, got: %v", cmdList, args[1])
 		}
 		err := unmarshalJSON(arg, &opts)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse %s args, got: %v", cmdTagList, arg)
+			return nil, errors.Wrapf(err, "failed to parse %s args, got: %v", cmdList, arg)
 		}
 	}
 
 	if len(opts.Select) == 0 {
-		return nil, fmt.Errorf("%s expects a `select` option with the list of fields to return", cmdTagList)
+		return nil, fmt.Errorf("%s expects a `select` option with the list of fields to return", cmdList)
 	}
-	var selection = newListSelection(opts.Select)
+	selection := newListSelection(opts.Select)
 
 	findOpts, err := opts.NewNoteFindOpts(notebook)
 	if err != nil {


### PR DESCRIPTION
[zk list](https://github.com/zk-org/zk/blob/main/docs/tips/editors-integration.md#zklist)'s error messages says `zk.tag.list` in the error message, when it should be `zk list`

# Repro Steps
call the following lua code in neovim with the zk lsp attached:
```lua
require("zk.api").list("", {}, function(err, notes)
    vim.print(err)
end)
```
the following error message is printed:
```
{
  code = -32600,
  message = "zk.tag.list expects a `select` option with the list of fields to return",
  <metatable> = {
    __tostring = <function 1>
  }
}
```