### PR TITLE
fix: Ctrl+E does no longer create new notes in chooser

### DIFF
--- a/internal/adapter/fzf/note_filter.go
+++ b/internal/adapter/fzf/note_filter.go
@@ -98,7 +98,7 @@ func (f *NoteFilter) Apply(notes []core.ContextualNote) ([]core.ContextualNote, 
 			bindings = append(bindings, Binding{
 				Keys:        newBinding,
 				Description: "create a note with the query as title" + suffix,
-				Action:      fmt.Sprintf(`abort+execute("%s" new "%s" --title {q} < /dev/tty > /dev/tty)`, zkBin, dir.Path),
+				Action:      fmt.Sprintf(`become("%s" new "%s" --title {q} < /dev/tty > /dev/tty)`, zkBin, dir.Path),
 			})
 		}
 	}


### PR DESCRIPTION
There was a --bind behavior change in fzf 0.53.0 which could be causing the error.

execute action is for executing an external program in the alternate screen without leaving fzf. In zk abort+execute was used to close fzf and open a zk instance.

become action is similar to execute, but it replaces the current fzf process with the specified command using execve(2) system call.

This should have similar behavior to the previous abort+execute action.

https://github.com/junegunn/fzf/issues/3865  
https://github.com/junegunn/fzf/blob/710ebdf9c14e0c88b0cfc843ce08edcdd4554571/man/man1/fzf.1#L1785-L1789  
https://github.com/junegunn/fzf/commit/6ea38b44384e7a09a3863465dc3cc7b93cd7e781

fixes: #518 