### PR TITLE
Use doublestar for group paths

### DIFF
--- a/docs/config/config-group.md
+++ b/docs/config/config-group.md
@@ -21,19 +21,18 @@ paths = [
 ```
 
 You can also use
-[glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) in `paths`.
+[glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) in `paths`:
 
 ```toml
 [group.journal]
+# Apply to child directories of "journal".
 paths = ["journal/*"]
-```
 
-If you omit `paths`, the directory named after the group will be inferred. Note
-the double quotes when using spaces or slashes for subdirectories.
+# Apply to all sub-directories of "journal" (i.e, recursively).
+paths = ["journal/**"]
 
-```toml
-# This will automatically apply to the `citations/web` directory
-[group."citations/web"]
+# Apply to all directories named "journal".
+paths = ["**/journal"]
 ```
 
 ## Overriding note configuration and extra variables

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	toml "github.com/pelletier/go-toml"
 	"github.com/zk-org/zk/internal/util/errors"
 	"github.com/zk-org/zk/internal/util/opt"
@@ -118,7 +119,7 @@ func (c Config) GroupNameForPath(path string) (string, error) {
 
 	for name, config := range c.Groups {
 		for _, groupPath := range config.Paths {
-			matches, err := filepath.Match(groupPath, path)
+			matches, err := doublestar.Match(groupPath, path)
 			if err != nil {
 				return "", errors.Wrapf(err, "failed to match group %s to %s", name, path)
 			} else if matches {

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -287,6 +287,15 @@ func TestGroupNameForPathApplyDeepestMatch(t *testing.T) {
 			"other": {
 				Paths: []string{"other"},
 			},
+			"star": {
+				Paths: []string{"star/star*.md"},
+			},
+			"false positive for doublestar": {
+				Paths: []string{"*/doublestar.md"},
+			},
+			"doublestar": {
+				Paths: []string{"**/doublestar.md"},
+			},
 		},
 	}
 
@@ -301,6 +310,18 @@ func TestGroupNameForPathApplyDeepestMatch(t *testing.T) {
 	name, err = config.GroupNameForPath("other/note.md")
 	assert.Nil(t, err)
 	assert.Equal(t, name, "other")
+
+	name, err = config.GroupNameForPath("star/start.md")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "star")
+
+	name, err = config.GroupNameForPath("star/star.md")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "star")
+
+	name, err = config.GroupNameForPath("double/star/doublestar.md")
+	assert.Nil(t, err)
+	assert.Equal(t, name, "doublestar")
 }
 
 func TestParseMergesGroupConfig(t *testing.T) {


### PR DESCRIPTION
As of right now, there's no way to match _across file separators_. For example, if I would like to match both `apple/ambrosia` and `melon/cantaloupe/ambrosia`, I would need to specify both paths:
```toml
[group."Ambrosia Fruit Varieties"]
paths = ["apple/ambrosia", "melon/cantaloupe/ambrosia"]
```
Note that `*/ambrosia` does __not__ work, since it doesn't match across `/`; it only matches `apple/ambrosia`
I would prefer to be able to specify just the `**/ambrosia` once, especially if I were a botanist trying to develop a highbush ambrosia blueberry that I would file it under `berry/blueberry/highbush/ambrosia`

We already use [doublestar](https://github.com/bmatcuk/doublestar) when looking for [excluded paths](https://github.com/zk-org/zk/blob/f4d3dc7113f5639fb262cb2d342419a8a1249814/internal/core/note_index.go#L140), so this doesn't even add a new dependency. I also added a couple tests, including over regular `*` globs.