### PR TITLE
Fix completion of markdown links with LSP titles

### DIFF
--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -856,7 +856,7 @@ func (s *Server) newTextEditForLink(notebook *core.Notebook, note core.MinimalNo
 			startOffset = -2
 		} else {
 			currentWord := doc.WordAt(pos)
-			startOffset = -2 - len(currentWord) 
+			startOffset = -2 - len(currentWord)
 		}
 	}
 

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -812,7 +812,7 @@ func (s *Server) newCompletionItem(notebook *core.Notebook, note core.MinimalNot
 		addTextEdits := []protocol.TextEdit{}
 
 		startOffset := -2
-		if (doc.LookBehind(pos, 2) != "[[") || (doc.LookBehind(pos, 2) != "((") {
+		if (doc.LookBehind(pos, 2) != "[[") && (doc.LookBehind(pos, 2) != "((") {
 			currentWord := doc.WordAt(pos)
 			// TODO: I think the -2 offset is not required for ((
 			startOffset = -2 - len(currentWord)

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -814,7 +814,6 @@ func (s *Server) newCompletionItem(notebook *core.Notebook, note core.MinimalNot
 		startOffset := -2
 		if (doc.LookBehind(pos, 2) != "[[") && (doc.LookBehind(pos, 2) != "((") {
 			currentWord := doc.WordAt(pos)
-			// TODO: I think the -2 offset is not required for ((
 			startOffset = -2 - len(currentWord)
 		}
 
@@ -853,7 +852,6 @@ func (s *Server) newTextEditForLink(notebook *core.Notebook, note core.MinimalNo
 		if (doc.LookBehind(pos, 2) == "[[") || (doc.LookBehind(pos, 2) == "((") {
 			startOffset = -2
 		} else {
-			// TODO: I think the -2 offset is not required for ((
 			currentWord := doc.WordAt(pos)
 			startOffset = -2 - len(currentWord) 
 		}

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -644,8 +644,11 @@ func (s *Server) refreshDiagnosticsOfDocument(doc *document, notify glsp.NotifyF
 // completion started automatically when typing an identifier, or manually.
 func (s *Server) buildInvokedCompletionList(notebook *core.Notebook, doc *document, position protocol.Position) ([]protocol.CompletionItem, error) {
 	currentWord := doc.WordAt(position)
-	// word includes (( but not [[
-	if strings.HasPrefix(doc.LookBehind(position, len(currentWord)+2), "[[") || strings.HasPrefix(doc.LookBehind(position, len(currentWord)), "((") {
+	// currentWord will include parentheses (( but not brackets [[.
+	// We check both if it's at len(currentWord) word and len(currentWord)-2 to account for auto-pair
+	if strings.HasPrefix(doc.LookBehind(position, len(currentWord)+2), "[[") ||
+		strings.HasPrefix(doc.LookBehind(position, len(currentWord)), "((") ||
+		(len(currentWord) >= 2 && strings.HasPrefix(doc.LookBehind(position, len(currentWord)-2), "((")) {
 		return s.buildLinkCompletionList(notebook, doc, position)
 	}
 


### PR DESCRIPTION
Fixes #435 and zk-org/zk-nvim#176.

After looking at the code and testing earlier versions, it seems that the issue was introduced in #397, which fixed the issue of triggering completion manually, but also introduced offsets that account for words instead of just using a `-2` offset. The `-2` offset worked for both `[[` and `((`, but the checks in #397 only accounted for `[[` which broke completion for `((`.

This PR just adds an extra condition to also catch `((`. Some notes:

- I don't really know go, so comments welcome
- It seems that trigger (non-auto) completion with  `[[|` was fixed by #397, but that `[[somewords|` still does not work. And it still does not work with these small updates (but `((|` works just like `[[`)
- I'm marking this as a draft for now because I want to double check the TODO comments I added (basically `((` is included in the word regex, but `[[` is not, so I need to account for that