### PR TITLE
Stop using `nix-env -iA` and add better instructions for Nix users

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,35 @@ brew install --HEAD zk
 
 ### Nix
 
-```sh
-# Run zk from Nix store without installing it:
+`zk` is available in nixpkgs and has a [Home Manager](https://github.com/nix-community/home-manager) module.
+
+If you want to run `zk` without permanently installing it:
+```
 nix run nixpkgs#zk
-# Or, to install it permanently:
-nix-env -iA zk
+```
+
+Or, if you want to create an ephemeral shell with `zk` available:
+```
+nix shell nixpkgs#zk
+```
+
+To permanently install `zk` on NixOS at the system level, include `nixpkgs.zk` in `environment.systemPackages` in your system configuration (`/etc/nixos/configuration.nix` by default):
+```
+environment.systemPackages = [
+  # Your other packages here
+  nixpkgs.zk
+];
+
+```
+
+If you are using [Home Manager](https://github.com/nix-community/home-manager), instead of installing for all users on the system, you can permanently install and configure `zk` just for your user via the Home Manager module. Add this to your Home Manager configuration:
+```
+programs.zk.enable = true;
+
+# Modify `${XDG_CONFIG_HOME}/zk/config.toml` through this attr
+programs.zk.settings = {
+  # Add your own configuration settings for zk here
+};
 ```
 
 ### Alpine Linux


### PR DESCRIPTION
This PR is an alternative to #506.

The original explanation for this PR's change is at <https://github.com/zk-org/zk/pull/506#issuecomment-2753773638> and is copied below.

---
Nix is a complex beast, with a package management system that looks alien compared to other package managers. A comment on a Github issue is a poor place to explain all that is Nix, so I'll try to provide a short summary of Nix here, and just the parts that are immediately relevant to this issue.

One of the primary points of Nix is declarative package management and configuration. Whereas with other package managers the way to install something would be a shell command, e.g. `sudo apt install firefox` and `sudo pacman -S firefox`, the best way to install a package in Nix is editing configuration files. This is conceptually similar to the `go.mod` for Go programs, but in the case of Nix, these configuration files defines a configuration of a system, including what programs are installed.

However, Nix also provides several other ways to "install" a package. This is where `nix-env -iA zk` and `nix profile install nixpkgs#zk` comes from. These two commands install the package imperatively, and I would argue both of these commands are anti-patterns, because Nix is designed for declarative package management.

Nix (and NixOS) configurations can get highly customized. Installation instructions necessarily have to assume the user has some basic Nix knowledge. I recommend these lines in the section for Nix in the readme: