### PR TITLE
Include version in release tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+VERSION.txt export-subst

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ CGO_ENABLED=1 GOARCH=arm64 go build -tags "fts5" -ldflags "-X=main.Version=`git 
 - `GOARCH=arm64` is only required for Apple Silicon chips.
 - `-tags "fts5"` enables the FTS option with `mattn/go-sqlite3`, which handles
   much of the magic behind `zk`'s `--match` filtering option.
-- ``-ldflags "-X=main.Version=`git describe --tags --match v[0-9]* 2> /dev/null` -X=main.Build=`git rev-parse --short HEAD`"``
+- ``-ldflags "-X=main.Version=`git describe --tags --match v[0-9]* 2> /dev/null`"``
   will automatically set `zk`'s build and version numbers using the latest Git
   tag and commit SHA.
 

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,0 +1,1 @@
+$Format:%(describe)$

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 )
 
 var Version = "dev"
-var Build = "dev"
 
 var root struct {
 	Init  cmd.Init  `cmd group:"zk" help:"Create a new notebook in the given directory."`

--- a/tests/flag-version.tesh
+++ b/tests/flag-version.tesh
@@ -1,3 +1,3 @@
 $ zk --version
->zk {{sh "git describe --tags --always --dirty --match v[0-9]* | cut -c 2-"}}
+>zk {{sh "[ -d .git ] && git describe --tags --always --dirty --match 'v[0-9]*' | cut -c2- || sed 's/^v//' VERSION.txt"}}
 

--- a/tests/flag-version.tesh
+++ b/tests/flag-version.tesh
@@ -1,3 +1,3 @@
 $ zk --version
->zk {{sh "git describe --tags | cut -c 2-"}}
+>zk {{sh "git describe --tags --always --dirty --match v[0-9]* | cut -c 2-"}}
 


### PR DESCRIPTION
Configure git to include the current version in tarballs generated via git-archive.

Fixes: https://github.com/zk-org/zk/issues/555
See: https://whynothugo.nl/journal/2024/12/16/injecting-project-versions-into-builds/