### PR TITLE
Skip changing to root directory for init alias

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func runAlias(container *cli.Container, args []string) (bool, error) {
 		os.Setenv("ZK_RUNNING_ALIAS", alias)
 
 		// Move to the current notebook's root directory before running the alias.
-		if notebook, err := container.CurrentNotebook(); err == nil {
+		if notebook, err := container.CurrentNotebook(); err == nil && alias != "init" {
 			cmdStr = `cd "` + notebook.Path + `" && ` + cmdStr
 		}
 


### PR DESCRIPTION
When a default notebook is set in the global configuration file, aliases are executed there (when no other notebook is found in the current working directory).

In the case of 'init' as alias, this always leads to an error

## Example `~/.config/zk/config.tml`:
```toml
[notebook]
dir = "~/notes"

[alias]
init = 'zk init --no-input'
```

## Behavior before:
```bash
$ mkdir ~/notes2 
$ cd ~/notes2 
$ zk init

zk: error: init: a notebook already exists in /home/cype/notes
```

## Behavior after:
```bash
$ mkdir ~/notes2 
$ cd ~/notes2 
$ zk init

Initialized a notebook in /home/cype/notes2
```

