### PR TITLE
feat: respect ZK_CONFIG_DIR as an override for global config location and update docs

### DIFF
--- a/docs/config/config-notebook.md
+++ b/docs/config/config-notebook.md
@@ -14,4 +14,4 @@ The following properties are customizable:
 
 - `dir` (string)
   - Path of the default notebook.
-  - Only available in the global config file (`~/.config/zk/config.toml`).
+  - Only available in the global config file (`$ZK_CONFIG_DIR/config.toml` or `$XDG_CONFIG_HOME/zk/config.toml`).

--- a/docs/config/config.md
+++ b/docs/config/config.md
@@ -18,9 +18,9 @@ Each [notebook](../notes/notebook.md) contains a configuration file used to cust
 
 ## Global configuration file
 
-You can also create a global configuration file to share aliases and settings across several notebooks. The global configuration is by default located at `~/.config/zk/config.toml`, but you can customize its location with the [`XDG_CONFIG_HOME`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) environment variable.
+You can also create a global configuration file to share aliases and settings across several notebooks. The default location is `~/.config/zk/config.toml`. You can override the location of the directory by setting `ZK_CONFIG_DIR`, or follow the XDG Base Directory specification by setting [`XDG_CONFIG_HOME`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-Notebook configuration files will inherit the settings defined in the global configuration file. You can also share templates by storing them under `~/.config/zk/templates/`.
+Notebook configuration files will inherit the settings defined in the global configuration file. You can also share templates by storing them under a `templates/` subdirectory, e.g. `~/.config/zk/templates/` or `$ZK_CONFIG_DIR/templates/`.
 
 ## Complete example
 

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -172,6 +172,9 @@ func locateGlobalConfig() (string, error) {
 
 // globalConfigDir returns the parent directory of the global configuration file.
 func globalConfigDir() string {
+	if path, ok := os.LookupEnv("ZK_CONFIG_DIR"); ok && path != "" {
+		return path
+	}
 	path, ok := os.LookupEnv("XDG_CONFIG_HOME")
 	if !ok {
 		home, ok := os.LookupEnv("HOME")


### PR DESCRIPTION
Always a nicety when programs provide an option like this. For my own usecase, I prefer to wrap config files into the nix store and point the program at it.  This variable adds this flexibility for zk.