### PR TITLE
Fix tesh cases failing with bash

### DIFF
--- a/tests/cmd-edit.tesh
+++ b/tests/cmd-edit.tesh
@@ -3,7 +3,7 @@ $ cd edit
 # Editor resolution
 
 # Checks that no editor is set in the current environment.
-$ echo $VISUAL $EDITOR $ZK_EDITOR
+$ echo -e $VISUAL $EDITOR $ZK_EDITOR
 >
 
 # No editor set
@@ -25,7 +25,7 @@ $ EDITOR=vim VISUAL=vim zk edit blue.md
 >{{working-dir}}/blue.md
 
 # ZK_EDITOR takes precedence over everything else.
-$ echo "[tool]\n editor = 'vim'" > .zk/config.toml
+$ echo -e "[tool]\n editor = 'vim'" > .zk/config.toml
 
 $ EDITOR=vim VISUAL=vim ZK_EDITOR=echo zk edit blue.md
 >{{working-dir}}/blue.md

--- a/tests/cmd-edit.tesh
+++ b/tests/cmd-edit.tesh
@@ -19,7 +19,7 @@ $ EDITOR=vim VISUAL=echo zk edit blue.md
 >{{working-dir}}/blue.md
 
 # The tool/editor config takes precedence over EDITOR and VISUAL.
-$ echo "[tool]\neditor = 'echo'" > .zk/config.toml
+$ echo -e "[tool]\neditor = 'echo'" > .zk/config.toml
 
 $ EDITOR=vim VISUAL=vim zk edit blue.md
 >{{working-dir}}/blue.md

--- a/tests/config-alias.tesh
+++ b/tests/config-alias.tesh
@@ -3,34 +3,34 @@ $ cd blank
 # Setup note fixtures.
 $ mkdir "red planet"
 $ touch "without-title.md"
-$ echo "# Yellow sun" > "yellow-sun.md"
+$ echo -e "# Yellow sun" > "yellow-sun.md"
 $ touch "red planet/blue moon.md"
 
 # Alias to override the default flags of a command.
-$ echo "[alias] list = 'zk list --quiet -fpath \$@'" > .zk/config.toml
+$ echo -e "[alias] list = 'zk list --quiet -fpath \$@'" > .zk/config.toml
 $ zk list -n2 --sort path-
 >yellow-sun.md
 >without-title.md
 
 # Shortcut for a native command.
-$ echo "[alias] ls = 'zk list \$@'" > .zk/config.toml
+$ echo -e "[alias] ls = 'zk list \$@'" > .zk/config.toml
 $ zk ls --quiet -fpath
 >red planet/blue moon.md
 >without-title.md
 >yellow-sun.md
 
 # Use $*
-$ echo "[note] filename = '\{{slug title}}'\n [alias] nt = 'zk new --dry-run --title \"\$*\"'" > .zk/config.toml
+$ echo -e "[note] filename = '\{{slug title}}'\n [alias] nt = 'zk new --dry-run --title \"\$*\"'" > .zk/config.toml
 $ zk nt Hello world
 2>{{working-dir}}/hello-world.md
 
 # Use the `ZK_NOTEBOOK_DIR` env variable.
-$ echo "[alias] nbdir = 'echo \$ZK_NOTEBOOK_DIR'" > .zk/config.toml
+$ echo -e "[alias] nbdir = 'echo \$ZK_NOTEBOOK_DIR'" > .zk/config.toml
 $ zk nbdir
 >{{working-dir}}
 
 # Test the "xargs formula"
-$ echo "[alias] xargs = 'zk list --quiet --format path --delimiter0 | xargs -0 head'" > .zk/config.toml
+$ echo -e "[alias] xargs = 'zk list --quiet --format path --delimiter0 | xargs -0 head'" > .zk/config.toml
 $ zk xargs
 >==> red planet/blue moon.md <==
 >

--- a/tests/config-format-markdown-link.tesh
+++ b/tests/config-format-markdown-link.tesh
@@ -3,8 +3,8 @@ $ cd blank
 # Setup note fixtures.
 $ mkdir "red planet"
 $ touch "without-title.md"
-$ echo "---\ncolor: yellow\n---\n# Yellow sun" > "yellow-sun.md"
-$ echo "# Blue moon" > "red planet/blue moon.md"
+$ echo -e "---\ncolor: yellow\n---\n# Yellow sun" > "yellow-sun.md"
+$ echo -e "# Blue moon" > "red planet/blue moon.md"
 
 # Default link format is `markdown`, without extension.
 $ zk list -qflink
@@ -13,7 +13,7 @@ $ zk list -qflink
 >[Yellow sun](yellow-sun)
 
 # Use `wiki` link format.
-$ echo "[format.markdown] link-format = 'wiki'" > .zk/config.toml
+$ echo -e "[format.markdown] link-format = 'wiki'" > .zk/config.toml
 $ zk list -qflink
 >[[without-title]]
 >[[red planet/blue moon]]
@@ -21,7 +21,7 @@ $ zk list -qflink
 
 # Use a custom link format.
 # {{json .}} will print the whole template context.
-$ echo "[format.markdown] link-format = '\{{json .}}'" > .zk/config.toml
+$ echo -e "[format.markdown] link-format = '\{{json .}}'" > .zk/config.toml
 $ zk list -qflink
 >{"filename":"without-title","path":"without-title","absPath":"{{working-dir}}/without-title","relPath":"without-title","title":"","metadata":{}}
 >{"filename":"blue moon","path":"red planet/blue moon","absPath":"{{working-dir}}/red planet/blue moon","relPath":"red planet/blue moon","title":"Blue moon","metadata":{}}
@@ -34,27 +34,27 @@ $ zk list -qflink -W "red planet"
 >{"filename":"yellow-sun","path":"yellow-sun","absPath":"{{working-dir}}/yellow-sun","relPath":"../yellow-sun","title":"Yellow sun","metadata":{"color":"yellow"}}
 
 # Don't drop the extension.
-$ echo "link-drop-extension = false" >> .zk/config.toml
+$ echo -e "link-drop-extension = false" >> .zk/config.toml
 $ zk list -qflink
 >{"filename":"without-title.md","path":"without-title.md","absPath":"{{working-dir}}/without-title.md","relPath":"without-title.md","title":"","metadata":{}}
 >{"filename":"blue moon.md","path":"red planet/blue moon.md","absPath":"{{working-dir}}/red planet/blue moon.md","relPath":"red planet/blue moon.md","title":"Blue moon","metadata":{}}
 >{"filename":"yellow-sun.md","path":"yellow-sun.md","absPath":"{{working-dir}}/yellow-sun.md","relPath":"yellow-sun.md","title":"Yellow sun","metadata":{"color":"yellow"}}
 
 # Encode paths.
-$ echo "link-encode-path = true" >> .zk/config.toml
+$ echo -e "link-encode-path = true" >> .zk/config.toml
 $ zk list -qflink
 >{"filename":"without-title.md","path":"without-title.md","absPath":"{{working-dir}}/without-title.md","relPath":"without-title.md","title":"","metadata":{}}
 >{"filename":"blue%20moon.md","path":"red%20planet/blue%20moon.md","absPath":"{{working-dir}}/red%20planet/blue%20moon.md","relPath":"red%20planet/blue%20moon.md","title":"Blue moon","metadata":{}}
 >{"filename":"yellow-sun.md","path":"yellow-sun.md","absPath":"{{working-dir}}/yellow-sun.md","relPath":"yellow-sun.md","title":"Yellow sun","metadata":{"color":"yellow"}}
 
 # Test individual template variables.
-$ echo "[format.markdown] link-format = '\{{filename}} \{{title}} \{{json metadata}}'" > .zk/config.toml
+$ echo -e "[format.markdown] link-format = '\{{filename}} \{{title}} \{{json metadata}}'" > .zk/config.toml
 $ zk list -qflink
 >without-title  {}
 >blue moon Blue moon {}
 >yellow-sun Yellow sun {"color":"yellow"}
 
-$ echo "[format.markdown] link-format = '\{{path}} \{{rel-path}} \{{abs-path}}'" > .zk/config.toml
+$ echo -e "[format.markdown] link-format = '\{{path}} \{{rel-path}} \{{abs-path}}'" > .zk/config.toml
 $ zk list -qflink -W red\ planet
 >without-title ../without-title {{working-dir}}/without-title
 >red planet/blue moon blue moon {{working-dir}}/red planet/blue moon

--- a/tests/config-format-markdown-tags.tesh
+++ b/tests/config-format-markdown-tags.tesh
@@ -1,9 +1,9 @@
 $ cd blank
 
-$ echo "#hashtag\n#multi-word tag#\n:colon-tag:" > note.md
+$ echo -e "#hashtag\n#multi-word tag#\n:colon-tag:" > note.md
 
 # By default, only hashtags are enabled.
-$ echo "" > .zk/config.toml
+$ echo -e "" > .zk/config.toml
 $ zk tag list
 >hashtag (1)
 >multi-word (1)
@@ -11,14 +11,14 @@ $ zk tag list
 2>Found 2 tags
 
 # Disable hashtags.
-$ echo "[format.markdown] hashtags = false" > .zk/config.toml
+$ echo -e "[format.markdown] hashtags = false" > .zk/config.toml
 $ zk index -fq
 $ zk tag list
 2>
 2>Found 0 tag
 
 # Enable colon tags.
-$ echo "[format.markdown] hashtags = false\n colon-tags = true" > .zk/config.toml
+$ echo -e "[format.markdown] hashtags = false\n colon-tags = true" > .zk/config.toml
 $ zk index -fq
 $ zk tag list
 >colon-tag (1)
@@ -26,7 +26,7 @@ $ zk tag list
 2>Found 1 tag
 
 # Enable Bear multi-word tags.
-$ echo "[format.markdown] multiword-tags = true" > .zk/config.toml
+$ echo -e "[format.markdown] multiword-tags = true" > .zk/config.toml
 $ zk index -fq
 $ zk tag list
 >hashtag (1)
@@ -35,7 +35,7 @@ $ zk tag list
 2>Found 2 tags
 
 # Bear multi-word tags require hashtags to be enabled
-$ echo "[format.markdown] hashtags = false\n multiword-tags = true" > .zk/config.toml
+$ echo -e "[format.markdown] hashtags = false\n multiword-tags = true" > .zk/config.toml
 $ zk index -fq
 $ zk tag list
 2>

--- a/tests/config-note-default-title.tesh
+++ b/tests/config-note-default-title.tesh
@@ -1,13 +1,13 @@
 $ cd blank
 
-$ echo "[note]\n filename = '\{{title}}'" > .zk/config.toml
+$ echo -e "[note]\n filename = '\{{title}}'" > .zk/config.toml
 
 # The default title is Untitled.
 $ zk new --dry-run
 2>{{working-dir}}/Untitled.md
 
 # Set a custom default title.
-$ echo "default-title = 'Sans titre'" >> .zk/config.toml
+$ echo -e "default-title = 'Sans titre'" >> .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/Sans titre.md
 

--- a/tests/config-note-exclude.tesh
+++ b/tests/config-note-exclude.tesh
@@ -8,7 +8,7 @@ $ touch dir/orange.md
 $ touch dir/subdir/apple.md
 
 # Ignore a file in the root directory.
-$ echo "[note]\n exclude = ['orange.md']" > .zk/config.toml
+$ echo -e "[note]\n exclude = ['orange.md']" > .zk/config.toml
 $ zk index -v
 >- added banana.md
 >- added dir/orange.md
@@ -21,7 +21,7 @@ $ zk index -v
 >  - 0 removed
 
 # Ignore with wildcards.
-$ echo "[note]\n exclude = ['*rang*', 'dir/*']" > .zk/config.toml
+$ echo -e "[note]\n exclude = ['*rang*', 'dir/*']" > .zk/config.toml
 $ zk index -v
 >- unchanged banana.md
 >- removed dir/orange.md
@@ -35,7 +35,7 @@ $ zk index -v
 >  - 1 removed
 
 # Unignore all files.
-$ echo "" > .zk/config.toml
+$ echo -e "" > .zk/config.toml
 $ zk index -v
 >- unchanged banana.md
 >- added dir/orange.md

--- a/tests/config-note-filename.tesh
+++ b/tests/config-note-filename.tesh
@@ -5,22 +5,22 @@ $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-z0-9]{4}"}}.md
 
 # Set a custom filename.
-$ echo "[note]\n filename = '\{{slug title}} - \{{format-date now \"%m-%d\"}}'" > .zk/config.toml
+$ echo -e "[note]\n filename = '\{{slug title}} - \{{format-date now \"%m-%d\"}}'" > .zk/config.toml
 $ zk new --title "A new note" --date "January 5th" --dry-run
 2>{{working-dir}}/a-new-note - 01-05.md
 
 # Set a custom extension.
-$ echo "extension = 'markdown'" >> .zk/config.toml
+$ echo -e "extension = 'markdown'" >> .zk/config.toml
 $ zk new --title "A new note" --date "January 5th" --dry-run
 2>{{working-dir}}/a-new-note - 01-05.markdown
 
 # Test the filename Handlebars variables.
 $ mkdir "a dir"
-$ echo "[note]\n filename = '\{{title}},\{{content}},\{{format-date now \"%m-%d\"}},\{{json extra}}'" > .zk/config.toml
-$ echo "Piped content" | zk new --interactive --title "A new note" --date "January 5th" --extra key=value --dry-run
+$ echo -e "[note]\n filename = '\{{title}},\{{content}},\{{format-date now \"%m-%d\"}},\{{json extra}}'" > .zk/config.toml
+$ echo -e "Piped content" | zk new --interactive --title "A new note" --date "January 5th" --extra key=value --dry-run
 2>{{working-dir}}/A new note,Piped content
 2>,01-05,{"key":"value"}.md
-$ echo "[note]\n filename = '\{{id}},\{{dir}},\{{json extra}},\{{env.ZK_NOTEBOOK_DIR}}'" > .zk/config.toml
-$ echo "Piped content" | zk new --title "A new note" --date "January 5th" --dry-run "a dir"
+$ echo -e "[note]\n filename = '\{{id}},\{{dir}},\{{json extra}},\{{env.ZK_NOTEBOOK_DIR}}'" > .zk/config.toml
+$ echo -e "Piped content" | zk new --title "A new note" --date "January 5th" --dry-run "a dir"
 2>{{working-dir}}/a dir/{{match "[a-z0-9]{4}"}},a dir,{},{{working-dir}}.md
 

--- a/tests/config-note-id.tesh
+++ b/tests/config-note-id.tesh
@@ -5,46 +5,46 @@ $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-z0-9]{4}"}}.md
 
 # Custom ID length.
-$ echo "[note] id-length = 100" > .zk/config.toml
+$ echo -e "[note] id-length = 100" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-z0-9]{100}"}}.md
 
 # Uppercase.
-$ echo "[note] id-length = 100\n id-case = 'upper'" > .zk/config.toml
+$ echo -e "[note] id-length = 100\n id-case = 'upper'" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[A-Z0-9]{100}"}}.md
 
 # Lowercase.
-$ echo "[note] id-length = 100\n id-case = 'lower'" > .zk/config.toml
+$ echo -e "[note] id-length = 100\n id-case = 'lower'" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-z0-9]{100}"}}.md
 
 # Mixed case.
-$ echo "[note] id-length = 100\n id-case = 'mixed'" > .zk/config.toml
+$ echo -e "[note] id-length = 100\n id-case = 'mixed'" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-zA-Z0-9]{100}"}}.md
 
 # Letters charset.
-$ echo "[note] id-length = 100\n id-charset = 'letters'" > .zk/config.toml
+$ echo -e "[note] id-length = 100\n id-charset = 'letters'" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-z]{100}"}}.md
 
 # Numbers charset.
-$ echo "[note] id-length = 100\n id-charset = 'numbers'" > .zk/config.toml
+$ echo -e "[note] id-length = 100\n id-charset = 'numbers'" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[0-9]{100}"}}.md
 
 # Alphanumeric charset.
-$ echo "[note] id-length = 100\n id-charset = 'alphanum'" > .zk/config.toml
+$ echo -e "[note] id-length = 100\n id-charset = 'alphanum'" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-z0-9]{100}"}}.md
 
 # Hexadecimal charset.
-$ echo "[note] id-length = 100\n id-charset = 'hex'" > .zk/config.toml
+$ echo -e "[note] id-length = 100\n id-charset = 'hex'" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-f0-9]{100}"}}.md
 
 # Custom charset.
-$ echo "[note] id-length = 100\n id-charset = 'abc01'" > .zk/config.toml
+$ echo -e "[note] id-length = 100\n id-charset = 'abc01'" > .zk/config.toml
 $ zk new --dry-run
 2>{{working-dir}}/{{match "[a-c01]{100}"}}.md

--- a/tests/config-note-language.tesh
+++ b/tests/config-note-language.tesh
@@ -1,6 +1,6 @@
 $ cd blank
 
-$ echo "[note]\n filename = '\{{slug title}} - \{{format-date now \"%B\"}}'" > .zk/config.toml
+$ echo -e "[note]\n filename = '\{{slug title}} - \{{format-date now \"%B\"}}'" > .zk/config.toml
 
 # The default language is `en`.
 # Note the & converted to `and` in the slug.
@@ -9,7 +9,7 @@ $ zk new --title "Foo \& Bar" --date "January 2nd" --dry-run
 
 # Set a custom language.
 # Note the & converted to `et` in the slug.
-$ echo "language = 'fr'" >> .zk/config.toml
+$ echo -e "language = 'fr'" >> .zk/config.toml
 $ zk new --title "Ceci \& cela" --date "January 2nd" --dry-run
 2>{{working-dir}}/ceci-et-cela - January.md
 

--- a/tests/config-note-template.tesh
+++ b/tests/config-note-template.tesh
@@ -2,17 +2,17 @@ $ cd blank
 
 $ mkdir .zk/templates
 
-$ echo "# \{{title}}" > .zk/templates/custom.md
+$ echo -e "# \{{title}}" > .zk/templates/custom.md
 
 # Set a custom template.
-$ echo "[note] filename = '\{{slug title}}'\n template = 'custom.md'" > .zk/config.toml
+$ echo -e "[note] filename = '\{{slug title}}'\n template = 'custom.md'" > .zk/config.toml
 
 $ zk new --title "A new note" --dry-run
 ># A new note
 2>{{working-dir}}/a-new-note.md
 
 # Template not found.
-$ echo "[note] template = 'not-found'" > .zk/config.toml
+$ echo -e "[note] template = 'not-found'" > .zk/config.toml
 1$ zk new --dry-run
 2>zk: error: new note: load template file failed: cannot find template at not-found
 

--- a/tests/issue-173.tesh
+++ b/tests/issue-173.tesh
@@ -3,7 +3,7 @@
 
 $ cd blank
 
-$ echo "[note]\n exclude = ['drafts/**']" > .zk/config.toml
+$ printf "[note]\nexclude = ['drafts/**']\n" > .zk/config.toml
 
 $ mkdir -p drafts/subdir/subdir
 $ echo "# This is not ignored" > not-ignored.md


### PR DESCRIPTION
Resolves #569 

Certain tesh cases are only failing in github ci. 

The common complaint is a backslash being seen as an illegal character. However there are some further issues, such as flags-version

The issue is that in some tests, config.toml files are being written from echo commands. In these echo commands, `\n` is being printed literarlly. `printf` needs to be used instead.

Commit 67c2dd5 proves this as `issue-173.tesh` no longer fails from that commit.

As to why tesh started failing only now / recently in CI with these standard cross shell incompatablity issues -- I have no idea.