### PR TITLE
Add tesh case for missing backlink

### DIFF
--- a/tests/cmd-list-missing-backlink.tesh
+++ b/tests/cmd-list-missing-backlink.tesh
@@ -1,0 +1,4 @@
+$ cd missing-backlink
+
+$ zk list -qf\{{title}} --missing-backlink
+>missing-backlink

--- a/tests/fixtures/missing-backlink/.zk/config.toml
+++ b/tests/fixtures/missing-backlink/.zk/config.toml
@@ -1,0 +1,11 @@
+[note]
+
+template = "default.md"
+
+[format.markdown]
+
+link-format = "wiki"
+hashtags = true
+colon-tags = false
+multiword-tags = false
+

--- a/tests/fixtures/missing-backlink/0wf6.md
+++ b/tests/fixtures/missing-backlink/0wf6.md
@@ -1,0 +1,3 @@
+# outgoing-link
+
+[[s0i1]]

--- a/tests/fixtures/missing-backlink/s0i1.md
+++ b/tests/fixtures/missing-backlink/s0i1.md
@@ -1,0 +1,3 @@
+# missing-backlink
+
+


### PR DESCRIPTION
`--missing-backlink` feature introduced in: #578 