### PR TITLE
Fix wrong end position being found for links

### DIFF
--- a/internal/adapter/markdown/link_position.go
+++ b/internal/adapter/markdown/link_position.go
@@ -20,9 +20,9 @@ func GetLinkPosition(link *ast.Link, source []byte) *LinkPosition {
 		return nil
 	}
 
-	// Find the position of the next sibling node (or EOF)…
+	// Find the position of the next node (or EOF)…
 	searchStart := len(source)
-	if next := ast.Node(link).NextSibling(); next != nil {
+	if next := nextNodeInAST(link); next != nil {
 		searchStart = next.Pos()
 	}
 
@@ -33,5 +33,18 @@ func GetLinkPosition(link *ast.Link, source []byte) *LinkPosition {
 		}
 	}
 
+	return nil
+}
+
+// nextNodeInAST finds the next node in document order.
+func nextNodeInAST(n ast.Node) ast.Node {
+	if next := n.NextSibling(); next != nil {
+		return next
+	}
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		if next := p.NextSibling(); next != nil {
+			return next
+		}
+	}
 	return nil
 }

--- a/internal/adapter/markdown/link_position_test.go
+++ b/internal/adapter/markdown/link_position_test.go
@@ -132,3 +132,56 @@ func TestLinkPositionMultipleLinks(t *testing.T) {
 	assert.Equal(t, pos2.Start, 15)
 	assert.Equal(t, pos2.End, 26)
 }
+
+// TestLinkPositionMultipleLinksOnSeparateLines tests that links on separate
+// lines (e.g., in a list) each get their correct positions.
+func TestLinkPositionMultipleLinksOnSeparateLines(t *testing.T) {
+	source := []byte("# Test\n\n- [one](e3bo)\n- [two](5qpt)\n- [three](kwpn)\n")
+	md := goldmark.New()
+
+	reader := text.NewReader(source)
+	root := md.Parser().Parse(reader, parser.WithContext(parser.NewContext()))
+
+	positions := make(map[string]LinkPosition)
+
+	ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		if link, ok := n.(*ast.Link); ok {
+			pos := GetLinkPosition(link, source)
+			if pos != nil {
+				positions[string(link.Destination)] = *pos
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+
+	expected := []struct {
+		dest  string
+		start int
+		end   int
+	}{
+		{"e3bo", 10, 21},
+		{"5qpt", 24, 35},
+		{"kwpn", 38, 51},
+	}
+
+	if got, want := len(positions), len(expected); got != want {
+		t.Fatalf("expected %d links, got %d", want, got)
+	}
+
+	for _, e := range expected {
+		pos, ok := positions[e.dest]
+		if !ok {
+			t.Fatalf("missing link with destination %q", e.dest)
+		}
+		if got, want := pos.Start, e.start; got != want {
+			t.Errorf("link %q: expected start %d, got %d", e.dest, want, got)
+		}
+		if got, want := pos.End, e.end; got != want {
+			t.Errorf("link %q: expected end %d, got %d", e.dest, want, got)
+		}
+	}
+}


### PR DESCRIPTION
When following an link via the LSP integration, the target for the first link is often used. When a link has no siblings, its end position is the last byte in the document.

The code uses NextSibling().Pos() for searching backwards to find the link's closing delimiter. This assumption holds when multiple inline elements are siblings within the same parent, but fails when each link is isolated in its own block with no next sibling.

Use the next node, regardless of whether it is a sibling.

Fixes: b514571d3c0d12d86e36bc87fd3ead2ee74d930e
Fixes: https://github.com/zk-org/zk/issues/702
