### PR TITLE
Add MacPorts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ official repos.
 sudo pacman -S zk
 ```
 
+### MacPorts
+
+```sh
+sudo port install zk
+```
+
 ### Build from scratch
 
 Make sure you have a working [Go 1.21+ installation](https://golang.org/), then


### PR DESCRIPTION
MacPorts has had zk for a while now, so it would be good to give macOS users an alternative method to Homebrew. I've added it in alphabetical order (after Arch) since it's a smaller package manager than Homebrew and Nix.
