### PR TITLE
Improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
-name: Bug report
+name: Bug Report
 description: File a bug report to help improve zk.
-title: "<do not include bug: feat: etc>"
+title: "Don't start with 'bug:'"
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,20 @@
+name: Enhancement
+description: Something that exists, but can be improved.
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description:
+        Describe the enhancement. What is currently not working so well? And how
+        can it be improved?
+  - type: checkboxes
+    id: ownership
+    attributes:
+      label: Ownership
+      description: "Do I plan to submit a PR for this feature?"
+      options:
+        - label: "No"
+        - label: "Yes"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,8 +1,8 @@
-name: Feature Request
-description: Suggest a new feature or enhancement for this project.
-title: "<do not include bug:, feat:, etc>"
+name: Feature
+description: Suggest a new feature for this project.
+title: "Don't start with 'feat:'"
 labels:
-  - feature request
+  - feature
 body:
   - type: textarea
     id: description
@@ -10,7 +10,7 @@ body:
       label: Description
       description:
         Describe the feature. Why should it be implemented? What problem does it
-        solve? What value does it bring? How would it help users?
+        solve? What value does it bring? How could it be implemented?
   - type: checkboxes
     id: ownership
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,11 +11,22 @@ body:
       description:
         Describe the feature. Why should it be implemented? What problem does
         it solve? What value does it bring? How would it help users?
+  # - type: checkboxes
+  #   id: ownership
+  #   attributes:
+  #     label: Ownership
+  #     description: Do I plan to submit a PR for this feature?
+  #     options:
+  #       - label: No
+  #       - label: Yes
   - type: checkboxes
-    id: ownership
+    id: checks
     attributes:
-      label: Ownership
-      description: Do I plan to submit a PR for this feature?
+      label: Check if applicable
+      description: |
+        :warning: Our time is limited and if we don't plan on fixing the reported bug myself, we might close this issue. No hard feelings.
+        :heart: But if you would like to contribute a fix yourself, **we'll be happy to guide you through the codebase and review a pull request**.
       options:
-        - label: No
-        - label: Yes
+        - label: I have searched the existing issues (**required**)
+          required: true
+        - label: I'm willing to help fix the problem and contribute a pull request

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -17,5 +17,5 @@ body:
       label: Ownership
       description: "Do I plan to submit a PR for this feature?"
       options:
-        - label: No
-        - label: Yes
+        - label: "No"
+        - label: "Yes"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,24 +9,13 @@ body:
     attributes:
       label: Description
       description:
-        Describe the feature. Why should it be implemented? What problem does
-        it solve? What value does it bring? How would it help users?
-  # - type: checkboxes
-  #   id: ownership
-  #   attributes:
-  #     label: Ownership
-  #     description: Do I plan to submit a PR for this feature?
-  #     options:
-  #       - label: No
-  #       - label: Yes
+        Describe the feature. Why should it be implemented? What problem does it
+        solve? What value does it bring? How would it help users?
   - type: checkboxes
-    id: checks
+    id: ownership
     attributes:
-      label: Check if applicable
-      description: |
-        :warning: Our time is limited and if we don't plan on fixing the reported bug myself, we might close this issue. No hard feelings.
-        :heart: But if you would like to contribute a fix yourself, **we'll be happy to guide you through the codebase and review a pull request**.
+      label: Ownership
+      description: "Do I plan to submit a PR for this feature?"
       options:
-        - label: I have searched the existing issues (**required**)
-          required: true
-        - label: I'm willing to help fix the problem and contribute a pull request
+        - label: No
+        - label: Yes


### PR DESCRIPTION
- Remove blank issues
- Separate issues for enhancements and features (enables auto tagging)
- Direct users to ommit 'feat:', 'bug:', etc from titles (makes reading clunky and everyone has their own flare as how to write it -- which makes it even more clunky to read in a group)

Appologies for the multiple pushes straight to dev here, zk-org was still set as origin on my work computer, when it's not on my personal computer...