### PR TITLE
Parse links to notes in frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Format: `<description> (by <contributor>, <pr number>)`
 
 ### Added
 
+- Parse links to notes in frontmatter (by @tjex, 710)
+
 ### Fixed
 
 - Indexing made significantly more performant (by @Keluaa, 735)

--- a/internal/adapter/markdown/markdown.go
+++ b/internal/adapter/markdown/markdown.go
@@ -85,6 +85,12 @@ func (p *Parser) ParseNoteContent(content string) (*core.NoteContent, error) {
 		return nil, err
 	}
 
+	fmLinks, err := p.parseFrontmatterLinks(frontmatter)
+	if err != nil {
+		return nil, err
+	}
+	links = append(links, fmLinks...)
+
 	title, bodyStart, err := parseTitle(frontmatter, root, bytes)
 	if err != nil {
 		return nil, err
@@ -269,6 +275,22 @@ func (p *Parser) parseLinks(root ast.Node, source []byte) ([]core.Link, error) {
 		return ast.WalkContinue, nil
 	})
 	return links, err
+}
+
+func (p *Parser) parseFrontmatterLinks(frontmatter frontmatter) ([]core.Link, error) {
+	links := []core.Link{}
+	for _, val := range frontmatter.values {
+		valStr := fmt.Sprint(val)
+		fmRoot := p.md.Parser().Parse(
+			text.NewReader([]byte(valStr)),
+		)
+		fmLinks, err := p.parseLinks(fmRoot, []byte(valStr))
+		if err != nil {
+			return nil, err
+		}
+		links = append(links, fmLinks...)
+	}
+	return links, nil
 }
 
 func extractLines(n ast.Node, source []byte) (content string, start, end int) {

--- a/internal/adapter/markdown/markdown_test.go
+++ b/internal/adapter/markdown/markdown_test.go
@@ -660,15 +660,29 @@ func TestParseLinkInFootnote(t *testing.T) {
 }
 
 func TestParseMetadataFromFrontmatter(t *testing.T) {
-	test := func(source string, expectedMetadata map[string]any) {
-		content := parse(t, source)
-		assert.Equal(t, content.Metadata, expectedMetadata)
-	}
-
-	test("", map[string]any{})
-	test("# A title", map[string]any{})
-	test("---\n---\n# A title", map[string]any{})
-	test(`---
+	tests := []struct {
+		name     string
+		source   string
+		expected map[string]any
+	}{
+		{
+			name:     "empty source",
+			source:   "",
+			expected: map[string]any{},
+		},
+		{
+			name:     "no metadata - title only",
+			source:   "# A title",
+			expected: map[string]any{},
+		},
+		{
+			name:     "empty frontmatter",
+			source:   "---\n---\n# A title",
+			expected: map[string]any{},
+		},
+		{
+			name: "frontmatter with title, tags and nested values",
+			source: `---
 title: A title
 tags:
   - tag1
@@ -678,13 +692,194 @@ nested:
 ---
 
 Paragraph
-`, map[string]any{
-		"title": "A title",
-		"tags":  []any{"tag1", "tag 2"},
-		"nested": map[string]any{
-			"key": "value",
+`,
+			expected: map[string]any{
+				"title": "A title",
+				"tags":  []any{"tag1", "tag 2"},
+				"nested": map[string]any{
+					"key": "value",
+				},
+			},
 		},
-	})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := parse(t, tt.source)
+			assert.Equal(t, tt.expected, content.Metadata)
+		})
+	}
+}
+
+func TestParseLinksInFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		expected []core.Link
+	}{
+		{
+			name: "wikilink in quoted string",
+			source: `---
+key: "[[wikilink]]"
+---
+`,
+			expected: []core.Link{
+				{
+					Title:        "wikilink",
+					Href:         "wikilink",
+					Type:         core.LinkTypeWikiLink,
+					IsExternal:   false,
+					Rels:         []core.LinkRelation{},
+					Snippet:      "[[wikilink]]",
+					SnippetStart: 0,
+					SnippetEnd:   12,
+				},
+			},
+		},
+		{
+			name: "wikilink in list",
+			source: `
+---
+key:
+	- [[wikilink]]
+---
+`,
+			expected: []core.Link{
+				{
+					Title:        "wikilink",
+					Href:         "wikilink",
+					Type:         core.LinkTypeWikiLink,
+					IsExternal:   false,
+					Rels:         []core.LinkRelation{},
+					Snippet:      "key:\n\t- [[wikilink]]",
+					SnippetStart: 5,
+					SnippetEnd:   25,
+				},
+			},
+		},
+		{
+			name: "wikilink inside list brackets",
+			source: `
+---
+key: [ [[wiki link in a list]] ]
+---
+`,
+			expected: []core.Link{
+				{
+					Title:        "wiki link in a list",
+					Href:         "wiki link in a list",
+					Type:         core.LinkTypeWikiLink,
+					IsExternal:   false,
+					Rels:         []core.LinkRelation{},
+					Snippet:      "key: [ [[wiki link in a list]] ]",
+					SnippetStart: 5,
+					SnippetEnd:   37,
+				},
+			},
+		},
+		{
+			name: "markdown-style link",
+			source: `---
+key: "[markdown title](path.md)"
+---
+`,
+			expected: []core.Link{
+				{
+					Title:        "markdown title",
+					Href:         "path.md",
+					Type:         core.LinkTypeMarkdown,
+					IsExternal:   false,
+					Rels:         []core.LinkRelation{},
+					Snippet:      "[markdown title](path.md)",
+					SnippetStart: 0,
+					SnippetEnd:   25,
+				},
+			},
+		},
+		{
+			name: "external link",
+			source: `---
+key: "https://www.foo.com"
+---
+`,
+			expected: []core.Link{
+				{
+					Title:        "https://www.foo.com",
+					Href:         "https://www.foo.com",
+					Type:         core.LinkTypeImplicit,
+					IsExternal:   true,
+					Rels:         []core.LinkRelation{},
+					Snippet:      "https://www.foo.com",
+					SnippetStart: 0,
+					SnippetEnd:   19,
+				},
+			},
+		},
+		{
+			name: "wikilink with pipe title",
+			source: `---
+key: "[[link with | title]]"
+---
+`,
+			expected: []core.Link{
+				{
+					Title:        "title",
+					Href:         "link with",
+					Type:         core.LinkTypeWikiLink,
+					IsExternal:   false,
+					Rels:         []core.LinkRelation{},
+					Snippet:      "[[link with | title]]",
+					SnippetStart: 0,
+					SnippetEnd:   21,
+				},
+			},
+		},
+		{
+			name: "wikilink unquoted",
+			source: `---
+key: [[link without quotes]]
+---
+`,
+			expected: []core.Link{
+				{
+					Title:        "link without quotes",
+					Href:         "link without quotes",
+					Type:         core.LinkTypeWikiLink,
+					IsExternal:   false,
+					Rels:         []core.LinkRelation{},
+					Snippet:      "[[link without quotes]]",
+					SnippetStart: 0,
+					SnippetEnd:   23,
+				},
+			},
+		},
+		{
+			name: "wikilink inside quoted string",
+			source: `---
+key: "A [[link inside]] a string"
+---
+`,
+			expected: []core.Link{
+				{
+					Title:        "link inside",
+					Href:         "link inside",
+					Type:         core.LinkTypeWikiLink,
+					IsExternal:   false,
+					Rels:         []core.LinkRelation{},
+					Snippet:      "A [[link inside]] a string",
+					SnippetStart: 0,
+					SnippetEnd:   26,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := parse(t, tt.source)
+			assert.Equal(t, tt.expected, content.Links)
+		})
+	}
 }
 
 func parse(t *testing.T, source string) core.NoteContent {

--- a/tests/fixtures/link-in-frontmatter/.zk/config.toml
+++ b/tests/fixtures/link-in-frontmatter/.zk/config.toml
@@ -1,0 +1,2 @@
+[note]
+filename = "{{id}}"

--- a/tests/fixtures/link-in-frontmatter/.zk/templates/default.md
+++ b/tests/fixtures/link-in-frontmatter/.zk/templates/default.md
@@ -1,0 +1,3 @@
+# {{title}}
+
+{{content}}

--- a/tests/fixtures/link-in-frontmatter/2bbc.md
+++ b/tests/fixtures/link-in-frontmatter/2bbc.md
@@ -1,0 +1,3 @@
+# Note has inbound link(s)
+
+EOF

--- a/tests/fixtures/link-in-frontmatter/dis3.md
+++ b/tests/fixtures/link-in-frontmatter/dis3.md
@@ -1,0 +1,7 @@
+---
+title: "Note has link in array"
+links:
+  - [[2bbc]]
+---
+
+EOF

--- a/tests/fixtures/link-in-frontmatter/jjst.md
+++ b/tests/fixtures/link-in-frontmatter/jjst.md
@@ -1,0 +1,6 @@
+---
+title: "Note has link in string"
+link: "This note links to [[2bbc]]"
+---
+
+EOF

--- a/tests/fixtures/link-in-frontmatter/zpbw.md
+++ b/tests/fixtures/link-in-frontmatter/zpbw.md
@@ -1,0 +1,6 @@
+---
+title: "Note has plain outbound link"
+links: [[2bbc]]
+---
+
+EOF

--- a/tests/link-in-frontmatter.tesh
+++ b/tests/link-in-frontmatter.tesh
@@ -1,0 +1,7 @@
+$ cd link-in-frontmatter
+
+$ zk list -qf\{{title}} --link-to 2bbc.md
+>Note has link in array
+>Note has link in string
+>Note has plain outbound link
+


### PR DESCRIPTION
Resolves: #709 #321 

Parses links in frontmatter blocks allowing features such as `--link-to`, `--linked-by` and therefore `:ZkBacklinks` etc in `zk-nvim`.

Links do work in frontmatter arrays (also itemised arrays), but I can't get the test case to work in Go. I have a tesh case for it though. The Go test states it wants a `Rel:` type of `{ "down" }`...?

I'm not nearly as familiar with the code base as you @WhyNotHugo and am not sure if I've missed any relevant structural steps... Your review would be appreciated!

I'm also not sure if this is the best appraoch. I needed to pass the frontmatter values to `p.parseLinks()` again, as from what I understand the preceding call at line 78 `markdown.go` runs with frontmatter removed from the ast. There is likely a more elegant way of handling this than I know of(?)


