### PR TITLE
Fix title text in issue templates for ownership

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -13,8 +13,7 @@ body:
   - type: checkboxes
     id: ownership
     attributes:
-      label: Ownership
-      description: "Do I plan to submit a PR for this feature?"
+      label: "Do I plan to submit a PR for this?"
       options:
         - label: "No"
         - label: "Yes"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,8 +14,7 @@ body:
   - type: checkboxes
     id: ownership
     attributes:
-      label: Ownership
-      description: "Do I plan to submit a PR for this feature?"
+      label: "Do I plan to submit a PR for this?"      
       options:
         - label: "No"
         - label: "Yes"


### PR DESCRIPTION
The description in templates are only visible when creating the PR. They're not
visible after creating the PR.

