### PR TITLE
lsp: guard textDocument/definition against missing client capabilities (#716)

### DIFF
--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -325,7 +325,7 @@ func NewServer(opts ServerOpts) *Server {
 			return nil, err
 		}
 
-		if isTrue(clientCapabilities.TextDocument.Definition.LinkSupport) {
+		if definitionLinkSupport(clientCapabilities) {
 			return protocol.LocationLink{
 				OriginSelectionRange: &link.Range,
 				TargetURI:            target.URI,
@@ -934,6 +934,18 @@ func boolPtr(v bool) *bool {
 
 func isTrue(v *bool) bool {
 	return v != nil && *v
+}
+
+// definitionLinkSupport reports whether the client advertised
+// textDocument.definition.linkSupport=true. The intermediate capability
+// objects are pointers and may be nil for clients (e.g. helix) that do
+// not advertise every sub-capability; dereferencing them blindly used
+// to crash the LSP server on textDocument/definition (#716).
+func definitionLinkSupport(caps protocol.ClientCapabilities) bool {
+	if caps.TextDocument == nil || caps.TextDocument.Definition == nil {
+		return false
+	}
+	return isTrue(caps.TextDocument.Definition.LinkSupport)
 }
 
 func stringPtr(v string) *string {

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -936,16 +936,9 @@ func isTrue(v *bool) bool {
 	return v != nil && *v
 }
 
-// definitionLinkSupport reports whether the client advertised
-// textDocument.definition.linkSupport=true. The intermediate capability
-// objects are pointers and may be nil for clients (e.g. helix) that do
-// not advertise every sub-capability; dereferencing them blindly used
-// to crash the LSP server on textDocument/definition (#716).
+// definitionLinkSupport reports whether the client advertised textDocument.definition.linkSupport=true.
 func definitionLinkSupport(caps protocol.ClientCapabilities) bool {
-	if caps.TextDocument == nil || caps.TextDocument.Definition == nil {
-		return false
-	}
-	return isTrue(caps.TextDocument.Definition.LinkSupport)
+	return caps.TextDocument != nil && caps.TextDocument.Definition != nil && isTrue(caps.TextDocument.Definition.LinkSupport)
 }
 
 func stringPtr(v string) *string {

--- a/internal/adapter/lsp/server_test.go
+++ b/internal/adapter/lsp/server_test.go
@@ -169,3 +169,50 @@ func TestServer_buildInvokedCompletionList(t *testing.T) {
 		})
 	}
 }
+
+// TestDefinitionLinkSupport_NilCapabilities is a regression test for #716:
+// clients (e.g. helix) that omit `textDocument` or `textDocument.definition`
+// from their initialize-capabilities used to nil-deref the LSP server when
+// handling textDocument/definition. definitionLinkSupport must treat a
+// missing intermediate object as "false" (no LinkSupport) rather than panic.
+func TestDefinitionLinkSupport_NilCapabilities(t *testing.T) {
+	// Whole TextDocument missing.
+	caps := protocol.ClientCapabilities{}
+	assert.Equal(t, definitionLinkSupport(caps), false)
+
+	// TextDocument present but Definition missing (helix's shape).
+	caps = protocol.ClientCapabilities{
+		TextDocument: &protocol.TextDocumentClientCapabilities{},
+	}
+	assert.Equal(t, definitionLinkSupport(caps), false)
+
+	// Definition present but LinkSupport pointer nil.
+	caps = protocol.ClientCapabilities{
+		TextDocument: &protocol.TextDocumentClientCapabilities{
+			Definition: &protocol.DefinitionClientCapabilities{},
+		},
+	}
+	assert.Equal(t, definitionLinkSupport(caps), false)
+
+	// Definition.LinkSupport explicitly false.
+	flag := false
+	caps = protocol.ClientCapabilities{
+		TextDocument: &protocol.TextDocumentClientCapabilities{
+			Definition: &protocol.DefinitionClientCapabilities{
+				LinkSupport: &flag,
+			},
+		},
+	}
+	assert.Equal(t, definitionLinkSupport(caps), false)
+
+	// Definition.LinkSupport explicitly true (the only true path).
+	flag = true
+	caps = protocol.ClientCapabilities{
+		TextDocument: &protocol.TextDocumentClientCapabilities{
+			Definition: &protocol.DefinitionClientCapabilities{
+				LinkSupport: &flag,
+			},
+		},
+	}
+	assert.Equal(t, definitionLinkSupport(caps), true)
+}

--- a/internal/adapter/lsp/server_test.go
+++ b/internal/adapter/lsp/server_test.go
@@ -170,23 +170,15 @@ func TestServer_buildInvokedCompletionList(t *testing.T) {
 	}
 }
 
-// TestDefinitionLinkSupport_NilCapabilities is a regression test for #716:
-// clients (e.g. helix) that omit `textDocument` or `textDocument.definition`
-// from their initialize-capabilities used to nil-deref the LSP server when
-// handling textDocument/definition. definitionLinkSupport must treat a
-// missing intermediate object as "false" (no LinkSupport) rather than panic.
 func TestDefinitionLinkSupport_NilCapabilities(t *testing.T) {
-	// Whole TextDocument missing.
 	caps := protocol.ClientCapabilities{}
 	assert.Equal(t, definitionLinkSupport(caps), false)
 
-	// TextDocument present but Definition missing (helix's shape).
 	caps = protocol.ClientCapabilities{
 		TextDocument: &protocol.TextDocumentClientCapabilities{},
 	}
 	assert.Equal(t, definitionLinkSupport(caps), false)
 
-	// Definition present but LinkSupport pointer nil.
 	caps = protocol.ClientCapabilities{
 		TextDocument: &protocol.TextDocumentClientCapabilities{
 			Definition: &protocol.DefinitionClientCapabilities{},
@@ -194,7 +186,6 @@ func TestDefinitionLinkSupport_NilCapabilities(t *testing.T) {
 	}
 	assert.Equal(t, definitionLinkSupport(caps), false)
 
-	// Definition.LinkSupport explicitly false.
 	flag := false
 	caps = protocol.ClientCapabilities{
 		TextDocument: &protocol.TextDocumentClientCapabilities{
@@ -205,7 +196,6 @@ func TestDefinitionLinkSupport_NilCapabilities(t *testing.T) {
 	}
 	assert.Equal(t, definitionLinkSupport(caps), false)
 
-	// Definition.LinkSupport explicitly true (the only true path).
 	flag = true
 	caps = protocol.ClientCapabilities{
 		TextDocument: &protocol.TextDocumentClientCapabilities{


### PR DESCRIPTION
Closes #716.

The `textDocument/definition` handler in `internal/adapter/lsp/server.go` derefs `clientCapabilities.TextDocument.Definition.LinkSupport` directly. Both `TextDocument` and `Definition` are `*Capabilities` pointers in `glsp/protocol_3_16`, and clients (e.g. helix) commonly send an initialize request that omits one or both, which nil-derefs and SIGSEGVs the LSP process whenever the user invokes `gd` after creating a link.

Adds a `definitionLinkSupport` helper that walks the optional chain safely, and replaces the call site. Regression test `TestDefinitionLinkSupport_NilCapabilities` covers the five reachable shapes (TextDocument nil, Definition nil, LinkSupport nil pointer, explicit false, explicit true). Without the fix, the test panics at the same frame as the issue stack trace; with the fix all five subcases pass.
