### PR TITLE
LSP option to append links to selected text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format: `<description> (by <contributor>, <pr number>)`
   @WhyNotHugo, 708)
 - Update strftime package, supporting `%g` and `%G` formats in the
   `{{format-date}}` helper (by @tjex, 723)
+- Option to append links to selected text, instead of replacing (by @tjex, 724)
 
 ### Fixed
 

--- a/docs/tips/editors-integration.md
+++ b/docs/tips/editors-integration.md
@@ -132,9 +132,11 @@ language-servers = ["zk"]
 
 <!-- prettier-ignore -->
 
-:::{note} This configuration disables Helix's
+:::{note}\
+This configuration disables Helix's
 [default language servers](https://docs.helix-editor.com/lang-support.html) for
-Markdown. :::
+Markdown.\
+:::
 
 </details>
 
@@ -210,7 +212,7 @@ quickly create a new note with a key binding. `zk.new` takes two arguments:
    | `date`                    | string               | A date of creation for the note in natural language, e.g. "tomorrow"                                                 |
    | `edit`                    | boolean              | When true, the editor will open the newly created note (**not supported by all editors**)                            |
    | `dryRun`                  | boolean              | When true, `zk` will not actually create the note on the file system, but will return its generated content and path |
-   | `append`                  | boolean              | Append the link to selection instead of replacing it.                                                  |
+   | `append`                  | boolean              | Append the link to selection instead of replacing it.                                                                |
    | `insertLinkAtLocation`    | location<sup>1</sup> | A location in another note where a link to the new note will be inserted                                             |
    | `insertContentAtLocation` | location<sup>1</sup> | A location in another note where the content of the new note will be inserted                                        |
 

--- a/docs/tips/editors-integration.md
+++ b/docs/tips/editors-integration.md
@@ -51,9 +51,9 @@ add the following in the settings file:
       "command": "zk",
       "args": ["lsp"],
       "trace.server": "messages",
-      "filetypes": ["markdown"],
-    },
-  },
+      "filetypes": ["markdown"]
+    }
+  }
 }
 ```
 
@@ -131,11 +131,10 @@ language-servers = ["zk"]
 ```
 
 <!-- prettier-ignore -->
-:::{note}
-This configuration disables Helix's
+
+:::{note} This configuration disables Helix's
 [default language servers](https://docs.helix-editor.com/lang-support.html) for
-Markdown.
-:::
+Markdown. :::
 
 </details>
 
@@ -155,9 +154,9 @@ file:
       "command": ["zk", "lsp"],
       "languageId": "markdown",
       "scopes": ["source.markdown"],
-      "syntaxes": ["Packages/MarkdownEditing/Markdown.sublime-syntax"],
-    },
-  },
+      "syntaxes": ["Packages/MarkdownEditing/Markdown.sublime-syntax"]
+    }
+  }
 }
 ```
 
@@ -211,6 +210,7 @@ quickly create a new note with a key binding. `zk.new` takes two arguments:
    | `date`                    | string               | A date of creation for the note in natural language, e.g. "tomorrow"                                                 |
    | `edit`                    | boolean              | When true, the editor will open the newly created note (**not supported by all editors**)                            |
    | `dryRun`                  | boolean              | When true, `zk` will not actually create the note on the file system, but will return its generated content and path |
+   | `append`                  | boolean              | Append the link to selection instead of replacing it.                                                  |
    | `insertLinkAtLocation`    | location<sup>1</sup> | A location in another note where a link to the new note will be inserted                                             |
    | `insertContentAtLocation` | location<sup>1</sup> | A location in another note where the content of the new note will be inserted                                        |
 
@@ -258,41 +258,41 @@ This LSP command calls `zk list` to search a notebook. It takes two arguments:
 1. A path to any file or directory in the notebook, to locate it.
 2. <details><summary>A dictionary of additional options (click to expand)</summary>
 
-    | Key              | Type         | Required? | Description                                                                                               |
-    | ---------------- | ------------ | --------- | --------------------------------------------------------------------------------------------------------- |
-    | `select`         | string array | Yes       | List of note fields to return<sup>1</sup>                                                                 |
-    | `hrefs`          | string array | No        | Find notes matching the given path, including its descendants                                             |
-    | `limit`          | integer      | No        | Limit the number of notes found                                                                           |
-    | `match`          | string array | No        | Terms to search for in the notes                                                                          |
-    | `exactMatch`     | boolean      | No        | (deprecated: use `matchStrategy`) Search for exact occurrences of the `match` argument (case insensitive) |
-    | `matchStrategy`  | string       | No        | Specify match strategy, which may be "fts" (default), "exact" or "re"                                     |
-    | `excludeHrefs`   | string array | No        | Ignore notes matching the given path, including its descendants                                           |
-    | `tags`           | string array | No        | Find notes tagged with the given tags                                                                     |
-    | `mention`        | string array | No        | Find notes mentioning the title of the given ones                                                         |
-    | `mentionedBy`    | string array | No        | Find notes whose title is mentioned in the given ones                                                     |
-    | `linkTo`         | string array | No        | Find notes which are linking to the given ones                                                            |
-    | `linkedBy`       | string array | No        | Find notes which are linked by the given ones                                                             |
-    | `orphan`         | boolean      | No        | Find notes which are not linked by any other note                                                         |
-    | `tagless`        | boolean      | No        | Find notes which have no tags                                                                             |
-    | `related`        | string array | No        | Find notes which might be related to the given ones                                                       |
-    | `maxDistance`    | integer      | No        | Maximum distance between two linked notes                                                                 |
-    | `recursive`      | boolean      | No        | Follow links recursively                                                                                  |
-    | `created`        | string       | No        | Find notes created on the given date                                                                      |
-    | `createdBefore`  | string       | No        | Find notes created before the given date                                                                  |
-    | `createdAfter`   | string       | No        | Find notes created after the given date                                                                   |
-    | `modified`       | string       | No        | Find notes modified on the given date                                                                     |
-    | `modifiedBefore` | string       | No        | Find notes modified before the given date                                                                 |
-    | `modifiedAfter`  | string       | No        | Find notes modified after the given date                                                                  |
-    | `sort`           | string array | No        | Order the notes by the given criterion                                                                    |
+   | Key              | Type         | Required? | Description                                                                                               |
+   | ---------------- | ------------ | --------- | --------------------------------------------------------------------------------------------------------- |
+   | `select`         | string array | Yes       | List of note fields to return<sup>1</sup>                                                                 |
+   | `hrefs`          | string array | No        | Find notes matching the given path, including its descendants                                             |
+   | `limit`          | integer      | No        | Limit the number of notes found                                                                           |
+   | `match`          | string array | No        | Terms to search for in the notes                                                                          |
+   | `exactMatch`     | boolean      | No        | (deprecated: use `matchStrategy`) Search for exact occurrences of the `match` argument (case insensitive) |
+   | `matchStrategy`  | string       | No        | Specify match strategy, which may be "fts" (default), "exact" or "re"                                     |
+   | `excludeHrefs`   | string array | No        | Ignore notes matching the given path, including its descendants                                           |
+   | `tags`           | string array | No        | Find notes tagged with the given tags                                                                     |
+   | `mention`        | string array | No        | Find notes mentioning the title of the given ones                                                         |
+   | `mentionedBy`    | string array | No        | Find notes whose title is mentioned in the given ones                                                     |
+   | `linkTo`         | string array | No        | Find notes which are linking to the given ones                                                            |
+   | `linkedBy`       | string array | No        | Find notes which are linked by the given ones                                                             |
+   | `orphan`         | boolean      | No        | Find notes which are not linked by any other note                                                         |
+   | `tagless`        | boolean      | No        | Find notes which have no tags                                                                             |
+   | `related`        | string array | No        | Find notes which might be related to the given ones                                                       |
+   | `maxDistance`    | integer      | No        | Maximum distance between two linked notes                                                                 |
+   | `recursive`      | boolean      | No        | Follow links recursively                                                                                  |
+   | `created`        | string       | No        | Find notes created on the given date                                                                      |
+   | `createdBefore`  | string       | No        | Find notes created before the given date                                                                  |
+   | `createdAfter`   | string       | No        | Find notes created after the given date                                                                   |
+   | `modified`       | string       | No        | Find notes modified on the given date                                                                     |
+   | `modifiedBefore` | string       | No        | Find notes modified before the given date                                                                 |
+   | `modifiedAfter`  | string       | No        | Find notes modified after the given date                                                                  |
+   | `sort`           | string array | No        | Order the notes by the given criterion                                                                    |
 
-    1. As the output of this command might be very verbose and put a heavy load on
-       the LSP client, you need to explicitly set which note fields you want to
-       receive with the `select` option. The following fields are available:
-       `filename`, `filenameStem`, `path`, `absPath`, `title`, `lead`, `body`,
-       `snippets`, `rawContent`, `wordCount`, `tags`, `metadata`, `created`,
-       `modified` and `checksum`.
+   1. As the output of this command might be very verbose and put a heavy load
+      on the LSP client, you need to explicitly set which note fields you want
+      to receive with the `select` option. The following fields are available:
+      `filename`, `filenameStem`, `path`, `absPath`, `title`, `lead`, `body`,
+      `snippets`, `rawContent`, `wordCount`, `tags`, `metadata`, `created`,
+      `modified` and `checksum`.
 
-    </details>
+   </details>
 
 `zk.list` returns the found notes as a JSON array.
 

--- a/internal/adapter/lsp/cmd_new.go
+++ b/internal/adapter/lsp/cmd_new.go
@@ -87,13 +87,14 @@ func executeCommandNew(notebook *core.Notebook, documents *documentStore, contex
 		minNote := note.AsMinimalNote()
 
 		var prefix string
+		// Inserts link inline after selected text.
 		if opts.Append {
 			r := opts.InsertLinkAtLocation.Range
 			opts.InsertLinkAtLocation.Range = protocol.Range{
 				Start: r.End,
 				End:   r.End,
 			}
-			// Links should be appended after a space
+			// Seperate last selected character and link with a space.
 			prefix = " "
 		}
 

--- a/internal/adapter/lsp/cmd_new.go
+++ b/internal/adapter/lsp/cmd_new.go
@@ -24,6 +24,7 @@ type cmdNewOpts struct {
 	Date                    string             `json:"date"`
 	Edit                    jsonBoolean        `json:"edit"`
 	DryRun                  jsonBoolean        `json:"dryRun"`
+	Append                  bool               `json:"append"`
 	InsertLinkAtLocation    *protocol.Location `json:"insertLinkAtLocation"`
 	InsertContentAtLocation *protocol.Location `json:"insertContentAtLocation"`
 }
@@ -85,10 +86,22 @@ func executeCommandNew(notebook *core.Notebook, documents *documentStore, contex
 	if !opts.DryRun && opts.InsertLinkAtLocation != nil {
 		minNote := note.AsMinimalNote()
 
+		var prefix string
+		if opts.Append {
+			r := opts.InsertLinkAtLocation.Range
+			opts.InsertLinkAtLocation.Range = protocol.Range{
+				Start: r.End,
+				End:   r.End,
+			}
+			// Links should be appended after a space
+			prefix = " "
+		}
+
 		info := &linkInfo{
 			note:     &minNote,
 			location: opts.InsertLinkAtLocation,
 			title:    &opts.Title,
+			prefix:   prefix,
 		}
 		err := linkNote(notebook, documents, context, info)
 

--- a/internal/adapter/lsp/util.go
+++ b/internal/adapter/lsp/util.go
@@ -67,6 +67,7 @@ type linkInfo struct {
 	note     *core.MinimalNote
 	location *protocol.Location
 	title    *string
+	prefix   string
 }
 
 func linkNote(notebook *core.Notebook, documents *documentStore, context *glsp.Context, info *linkInfo) error {
@@ -107,6 +108,8 @@ func linkNote(notebook *core.Notebook, documents *documentStore, context *glsp.C
 	if err != nil {
 		return err
 	}
+
+	link = info.prefix + link
 
 	go context.Call(protocol.ServerWorkspaceApplyEdit, protocol.ApplyWorkspaceEditParams{
 		Edit: protocol.WorkspaceEdit{


### PR DESCRIPTION
Currently when creating a note with text selection as context, the selected text
is replaced with link of the resultant note.

This PR adds an `append = true` option to our LSP, which will append the link to
the selected text instead of replacing it.

E.g.,

```
|Selected text for creation|.
```

```
Selected text for note creation [[link-to-note]]|.
```

Motivation here is that often the selected text is important context for the
current note. Completely replacing it with a link is only practical when the
title of the note is used as the link text. If a link format takes a different
form (like using the note filename as the link text) then replacing the selected
text with this link destroys the comprehension of the note.

The append option therefore provides these users with a smoother workflow when
performing text selection based note creation.
