### PR TITLE
Expand ~ and env vars in paths passed to --notebook-dir and --working-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Format: `<description> (by <contributor>, <pr number>)`
 
 ### Fixed
 
+- Paths with `~` and env variables no longer error when passed to
+  `--notebook-dir` and `--working-dir` (by @tjex, 732)
+
 ## 0.15.4
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zk-org/zk/internal/cli/cmd"
 	"github.com/zk-org/zk/internal/core"
 	executil "github.com/zk-org/zk/internal/util/exec"
+	"github.com/zk-org/zk/internal/util/paths"
 )
 
 var Version = "dev"
@@ -307,7 +308,11 @@ func parseDirs(args []string) (cli.Dirs, []string, error) {
 			}
 
 			if option != "" && value != "" {
-				path, err := filepath.Abs(value)
+				valueAbs, err := paths.ExpandPath(value)
+				if err != nil {
+					return "", newArgs, err
+				}
+				path, err := filepath.Abs(valueAbs)
 				return path, newArgs, err
 			} else if option != "" && value == "" {
 				return "", newArgs, errors.New(option + " requires a path argument")

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/zk-org/zk/internal/cli"
+)
+
+func Test_parseDirsPathExpansion(t *testing.T) {
+	user, _ := user.Current()
+	_ = os.Setenv("FOO", "/home/foo")
+	tests := []struct {
+		name     string
+		args     []string
+		wantDirs cli.Dirs
+	}{
+		{
+			name:     "With tilde (working dir)",
+			args:     []string{"--working-dir=~/notes"},
+			wantDirs: cli.Dirs{WorkingDir: user.HomeDir + "/notes"},
+		},
+		{
+			name:     "With tilde (notebook dir)",
+			args:     []string{"--notebook-dir=~/notes"},
+			wantDirs: cli.Dirs{NotebookDir: user.HomeDir + "/notes"},
+		},
+		{
+			name:     "With absolute path",
+			args:     []string{"--notebook-dir=" + user.HomeDir + "/notes"},
+			wantDirs: cli.Dirs{NotebookDir: user.HomeDir + "/notes"},
+		},
+		{
+			name:     "With environment variable in path",
+			args:     []string{"--notebook-dir=${FOO}/notes"},
+			wantDirs: cli.Dirs{NotebookDir: os.Getenv("FOO") + "/notes"},
+		},
+		{
+			name:     "With environment variable and two string argument",
+			args:     []string{"--notebook-dir", "${FOO}/notes"},
+			wantDirs: cli.Dirs{NotebookDir: os.Getenv("FOO") + "/notes"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cliDirs, _, gotErr := parseDirs(tt.args)
+			workDir := cliDirs.WorkingDir
+			noteDir := cliDirs.NotebookDir
+			if gotErr != nil {
+				t.Errorf("parseDirs() failed: %v", gotErr)
+			}
+			if workDir != tt.wantDirs.WorkingDir {
+				t.Errorf("parseDirs() got WorkingDir = %v, want %v", cliDirs.WorkingDir, tt.wantDirs.WorkingDir)
+			}
+			if noteDir != tt.wantDirs.NotebookDir {
+				t.Errorf("parseDirs() got NotebookDir = %v, want %v", cliDirs.NotebookDir, tt.wantDirs.NotebookDir)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves zk-org/zk#732

Issue was here in `main.go` +309:

```go
			if option != "" && value != "" {
				path, err := filepath.Abs(value)
				return path, newArgs, err
			...
      }
```

...

`filepath.Abs(string)` returns an absolute path only if the passed string is also an
absolute filepath. Otherwise it appends the passed string to the current working
directory in order to build an absolute path.
