### PR TITLE
Parallel update of links

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/yuin/goldmark v1.8.1
 	github.com/yuin/goldmark-meta v1.1.0
 	github.com/zk-org/pretty v0.2.4
+	golang.org/x/sync v0.18.0
 	gopkg.in/djherbis/times.v1 v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.18.0 h1:kr88TuHDroi+UVf+0hZnirlk8o8T+4MrK6mr60WkH/I=
+golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/adapter/sqlite/note_index.go
+++ b/internal/adapter/sqlite/note_index.go
@@ -5,12 +5,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/zk-org/zk/internal/core"
 	"github.com/zk-org/zk/internal/util"
 	"github.com/zk-org/zk/internal/util/paths"
 	strutil "github.com/zk-org/zk/internal/util/strings"
+	"golang.org/x/sync/errgroup"
 )
 
 // NoteIndex persists note indexing results in the SQLite database.
@@ -188,8 +188,7 @@ func (ni *NoteIndex) batchFixExistingLinks(dao *dao, ids []core.NoteID, paths []
 	// which is a considerable amount of work. We do so without using all CPU cores at once.
 	maxWorkers := min(max(runtime.GOMAXPROCS(0)-2, 1), len(links))
 	linksPerWorker := len(links) / maxWorkers
-	firstError := make(chan error, 1)
-	var wg sync.WaitGroup
+	group := new(errgroup.Group)
 	for wid := range maxWorkers {
 		start := linksPerWorker * wid
 		end := linksPerWorker * (wid + 1)
@@ -197,29 +196,17 @@ func (ni *NoteIndex) batchFixExistingLinks(dao *dao, ids []core.NoteID, paths []
 			// The last worker does a bit more work
 			end += len(links) % maxWorkers
 		}
-		wg.Add(1)
-		go func(start, end int) {
+		group.Go(func() error {
 			for _, link := range links[start:end] {
 				err := fixLink(link)
 				if err != nil {
-					select {
-					case firstError <- err:
-					default:
-					}
+					return err
 				}
 			}
-			wg.Done()
-		}(start, end)
+			return nil
+		})
 	}
-
-	wg.Wait()
-	close(firstError)
-	select {
-	case err := <-firstError:
-		return err
-	default:
-		return nil
-	}
+	return group.Wait()
 }
 
 // linkMatchesPath returns whether the given link can be used to reach the

--- a/internal/adapter/sqlite/note_index.go
+++ b/internal/adapter/sqlite/note_index.go
@@ -1,11 +1,11 @@
 package sqlite
 
 import (
-	"path/filepath"
-	"regexp"
-	"strings"
-
 	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
 
 	"github.com/zk-org/zk/internal/core"
 	"github.com/zk-org/zk/internal/util"
@@ -107,7 +107,7 @@ func (ni *NoteIndex) IndexedPaths() (metadata <-chan paths.Metadata, err error) 
 }
 
 // Add implements core.NoteIndex.
-func (ni *NoteIndex) Add(note core.Note) (id core.NoteID, err error) {
+func (ni *NoteIndex) Add(note core.Note, fixLinks bool) (id core.NoteID, err error) {
 	err = ni.commit(func(dao *dao) error {
 		id, err = dao.notes.Add(note)
 		if err != nil {
@@ -120,9 +120,11 @@ func (ni *NoteIndex) Add(note core.Note) (id core.NoteID, err error) {
 			return err
 		}
 
-		err = ni.fixExistingLinks(dao, note.ID, note.Path)
-		if err != nil {
-			return err
+		if fixLinks {
+			err = ni.fixExistingLinks(dao, note.ID, note.Path)
+			if err != nil {
+				return err
+			}
 		}
 
 		return ni.associateTags(dao.collections, id, note.Tags)
@@ -134,32 +136,90 @@ func (ni *NoteIndex) Add(note core.Note) (id core.NoteID, err error) {
 	return
 }
 
-// fixExistingLinks will go over all indexed links and update their target to
-// the given id if they match the given path better than their current
-// targetPath.
 func (ni *NoteIndex) fixExistingLinks(dao *dao, id core.NoteID, path string) error {
+	return ni.batchFixExistingLinks(dao, []core.NoteID{id}, []string{path})
+}
+
+// BatchUpdateLinks will go over all indexed links and update their target to
+// one of the given ids if its path better matches their current targetPath.
+func (ni *NoteIndex) BatchUpdateLinks(ids []core.NoteID, paths []string) error {
+	return ni.commit(func(dao *dao) error {
+		return ni.batchFixExistingLinks(dao, ids, paths)
+	})
+}
+
+func (ni *NoteIndex) batchFixExistingLinks(dao *dao, ids []core.NoteID, paths []string) error {
 	links, err := dao.links.FindInternal()
-	if err != nil {
+	if err != nil || len(links) == 0 {
 		return err
 	}
 
-	for _, link := range links {
-		// To find the best match possible, shortest paths take precedence.
-		// See https://github.com/zk-org/zk/issues/23
-		if link.TargetPath != "" && len(link.TargetPath) < len(path) {
-			continue
+	fixLink := func(link core.ResolvedLink) error {
+		bestTargetPath := link.TargetPath
+		bestMatch := -1
+		for i, path := range paths {
+			// To find the best match possible, shortest paths take precedence.
+			// See https://github.com/zk-org/zk/issues/23
+			if bestTargetPath != "" && len(bestTargetPath) < len(path) {
+				continue
+			}
+
+			matches, err := ni.linkMatchesPath(link, path)
+			if err != nil {
+				return err
+			}
+			if matches {
+				bestTargetPath = path
+				bestMatch = i
+			}
 		}
 
-		matches, err := ni.linkMatchesPath(link, path)
-		if matches && err == nil {
-			err = dao.links.SetTargetID(link.ID, id)
+		if bestMatch != -1 {
+			err = dao.links.SetTargetID(link.ID, ids[bestMatch])
+			if err != nil {
+				return err
+			}
 		}
-		if err != nil {
-			return err
-		}
+
+		return nil
 	}
 
-	return nil
+	// Update the links in parallel: we must parse through the links of all notes,
+	// which is a considerable amount of work. We do so without using all CPU cores at once.
+	maxWorkers := min(max(runtime.GOMAXPROCS(0)-2, 1), len(links))
+	linksPerWorker := len(links) / maxWorkers
+	firstError := make(chan error, 1)
+	var wg sync.WaitGroup
+	for wid := range maxWorkers {
+		start := linksPerWorker * wid
+		end := linksPerWorker * (wid + 1)
+		if wid == maxWorkers-1 {
+			// The last worker does a bit more work
+			end += len(links) % maxWorkers
+		}
+		wg.Add(1)
+		go func(start, end int) {
+			for _, link := range links[start:end] {
+				err := fixLink(link)
+				if err != nil {
+					select {
+					case firstError <- err:
+					default:
+					}
+				}
+			}
+			wg.Done()
+		}(start, end)
+	}
+
+	wg.Wait()
+	close(firstError)
+	select {
+	case err := <-firstError:
+		return err
+	default:
+		return nil
+	}
 }
 
 // linkMatchesPath returns whether the given link can be used to reach the
@@ -167,29 +227,28 @@ func (ni *NoteIndex) fixExistingLinks(dao *dao, id core.NoteID, path string) err
 func (ni *NoteIndex) linkMatchesPath(link core.ResolvedLink, path string) (bool, error) {
 	// Remove any anchor at the end of the HREF, since it's most likely
 	// matching a sub-section in the note.
-	href := strings.SplitN(link.Href, "#", 2)[0]
-
-	matchString := func(pattern string, s string) bool {
-		reg := regexp.MustCompile(pattern)
-		return reg.MatchString(s)
+	href := link.Href
+	if hashPos := strings.LastIndexByte(link.Href, '#'); hashPos != -1 {
+		href = link.Href[:hashPos]
 	}
 
 	matches := func(href string, allowPartialHref bool) bool {
 		if href == "" {
 			return false
 		}
-		href = regexp.QuoteMeta(href)
-
-		if allowPartialHref {
-			if matchString("^(.*/)?[^/]*"+href+"[^/]*$", path) {
-				return true
-			}
-			if matchString(".*"+href+".*", path) {
-				return true
-			}
+		pos := strings.Index(path, href)
+		if allowPartialHref && pos != -1 {
+			// Match if 'href' is anywhere in 'path'
+			return true
 		}
+		// Match only if 'href' prefixes 'path', and 'path' isn't a directory named "href/"
+		// e.g. with 'href="dir"', match "dir/file", "dir", or "dir2", but not "dir/"
+		return pos == 0 && !(len(path) == len(href)+1 && path[len(path)-1] == '/')
+	}
 
-		return matchString("^(?:"+href+"[^/]*|"+href+"/.+)$", path)
+	allowPartialMatch := link.Type == core.LinkTypeWikiLink
+	if matches(href, allowPartialMatch) {
+		return true, nil
 	}
 
 	baseDir := filepath.Join(ni.notebookPath, filepath.Dir(link.SourcePath))
@@ -199,8 +258,7 @@ func (ni *NoteIndex) linkMatchesPath(link core.ResolvedLink, path string) (bool,
 		}
 	}
 
-	allowPartialMatch := (link.Type == core.LinkTypeWikiLink)
-	return matches(href, allowPartialMatch), nil
+	return false, nil
 }
 
 // relNotebookHref makes the given href (which is relative to baseDir) relative

--- a/internal/adapter/sqlite/note_index.go
+++ b/internal/adapter/sqlite/note_index.go
@@ -228,7 +228,7 @@ func (ni *NoteIndex) linkMatchesPath(link core.ResolvedLink, path string) (bool,
 	// Remove any anchor at the end of the HREF, since it's most likely
 	// matching a sub-section in the note.
 	href := link.Href
-	if hashPos := strings.LastIndexByte(link.Href, '#'); hashPos != -1 {
+	if hashPos := strings.IndexByte(link.Href, '#'); hashPos != -1 {
 		href = link.Href[:hashPos]
 	}
 
@@ -240,10 +240,19 @@ func (ni *NoteIndex) linkMatchesPath(link core.ResolvedLink, path string) (bool,
 		if allowPartialHref && pos != -1 {
 			// Match if 'href' is anywhere in 'path'
 			return true
+		} else if pos != 0 {
+			// Otherwise 'path' must start with 'href'
+			return false
 		}
-		// Match only if 'href' prefixes 'path', and 'path' isn't a directory named "href/"
-		// e.g. with 'href="dir"', match "dir/file", "dir", or "dir2", but not "dir/"
-		return pos == 0 && !(len(path) == len(href)+1 && path[len(path)-1] == '/')
+
+		slashPos := strings.IndexByte(path[len(href):], '/')
+		if slashPos != -1 {
+			// 'href/abc', 'href/a/b/c', or 'href/' but not 'hrefAnd/something/after'
+			return slashPos == 0
+		}
+
+		// 'href' or 'hrefSomeSuffix'
+		return true
 	}
 
 	allowPartialMatch := link.Type == core.LinkTypeWikiLink

--- a/internal/adapter/sqlite/note_index_test.go
+++ b/internal/adapter/sqlite/note_index_test.go
@@ -45,7 +45,7 @@ func TestNoteIndexAddWithLinks(t *testing.T) {
 				Snippet:    "External [URL](http://example.com)",
 			},
 		},
-	})
+	}, true)
 	assert.Nil(t, err)
 
 	rows := queryLinkRows(t, db.db, fmt.Sprintf("source_id = %d", id))
@@ -98,7 +98,7 @@ func TestNoteIndexAddFillsLinksMissingTargetId(t *testing.T) {
 
 	id, err := index.Add(core.Note{
 		Path: "missing_target.md",
-	})
+	}, true)
 	assert.Nil(t, err)
 
 	rows := queryLinkRows(t, db.db, fmt.Sprintf("target_id = %d", id))
@@ -192,7 +192,7 @@ func TestNoteIndexAddWithTags(t *testing.T) {
 	id, err := index.Add(core.Note{
 		Path: "log/added.md",
 		Tags: []string{"new-tag", "fiction"},
-	})
+	}, true)
 	assert.Nil(t, err)
 	assertSQL(true)
 	assertTaggedOrNot(t, db, true, id, "new-tag")

--- a/internal/adapter/sqlite/note_integration_test.go
+++ b/internal/adapter/sqlite/note_integration_test.go
@@ -29,9 +29,9 @@ func TestNoteIndexFindByHrefPrefixBug(t *testing.T) {
 	}
 
 	// Add notes to the index
-	shorterID, err := index.Add(shorterNote)
+	shorterID, err := index.Add(shorterNote, true)
 	assert.Nil(t, err)
-	longerID, err := index.Add(longerNote)
+	longerID, err := index.Add(longerNote, true)
 	assert.Nil(t, err)
 
 	t.Logf("Shorter note ID: %d, Longer note ID: %d", shorterID, longerID)

--- a/internal/core/note_index.go
+++ b/internal/core/note_index.go
@@ -28,11 +28,13 @@ type NoteIndex interface {
 	// Indexed returns the list of indexed note file metadata.
 	IndexedPaths() (<-chan paths.Metadata, error)
 	// Add indexes a new note.
-	Add(note Note) (NoteID, error)
+	Add(note Note, fixLinks bool) (NoteID, error)
 	// Update resets the metadata of an already indexed note.
 	Update(note Note) error
 	// Remove deletes a note from the index.
 	Remove(path string) error
+	// BatchUpdateLinks updates the links to existing notes
+	BatchUpdateLinks(ids []NoteID, paths []string) error
 
 	// Commit performs a set of operations atomically.
 	Commit(transaction func(idx NoteIndex) error) error
@@ -151,6 +153,9 @@ func (t *indexTask) execute(callback func(change paths.DiffChange)) (NoteIndexin
 		return stats, fmt.Errorf("finding indexed paths failed: %w", err)
 	}
 
+	addedNotes := make([]NoteID, 0)
+	addedPaths := make([]string, 0)
+
 	// FIXME: Use the FS?
 	count, err := paths.Diff(source, target, force, func(change paths.DiffChange) error {
 		callback(change)
@@ -162,7 +167,11 @@ func (t *indexTask) execute(callback func(change paths.DiffChange)) (NoteIndexin
 			stats.AddedCount += 1
 			note, err := t.parser.ParseNoteAt(absPath)
 			if note != nil {
-				_, err = t.index.Add(*note)
+				// Link update is done afterward on all added notes, for performance reasons
+				var id NoteID
+				id, err = t.index.Add(*note, false)
+				addedNotes = append(addedNotes, id)
+				addedPaths = append(addedPaths, note.Path)
 			}
 			t.logger.Err(err)
 
@@ -182,6 +191,14 @@ func (t *indexTask) execute(callback func(change paths.DiffChange)) (NoteIndexin
 
 		return nil
 	})
+	if err != nil {
+		return stats, fmt.Errorf("finding indexed paths failed: %w", err)
+	}
+
+	err = t.index.BatchUpdateLinks(addedNotes, addedPaths)
+	if err != nil {
+		return stats, fmt.Errorf("updating links failed: %w", err)
+	}
 
 	for _, ignored := range ignoredFiles {
 		print("- ignored " + ignored.Path + ": " + ignored.Reason)

--- a/internal/core/note_new_test.go
+++ b/internal/core/note_new_test.go
@@ -506,10 +506,11 @@ func (m *noteIndexAddMock) FindLinksBetweenNotes(ids []NoteID) ([]ResolvedLink, 
 func (m *noteIndexAddMock) FindCollections(kind CollectionKind, sorters []CollectionSorter) ([]Collection, error) {
 	return nil, nil
 }
-func (m *noteIndexAddMock) IndexedPaths() (<-chan paths.Metadata, error)       { return nil, nil }
-func (m *noteIndexAddMock) Add(note Note) (NoteID, error)                      { return m.ReturnedID, nil }
-func (m *noteIndexAddMock) Update(note Note) error                             { return nil }
-func (m *noteIndexAddMock) Remove(path string) error                           { return nil }
-func (m *noteIndexAddMock) Commit(transaction func(idx NoteIndex) error) error { return nil }
-func (m *noteIndexAddMock) NeedsReindexing() (bool, error)                     { return false, nil }
-func (m *noteIndexAddMock) SetNeedsReindexing(needsReindexing bool) error      { return nil }
+func (m *noteIndexAddMock) IndexedPaths() (<-chan paths.Metadata, error)        { return nil, nil }
+func (m *noteIndexAddMock) Add(note Note, fixLinks bool) (NoteID, error)        { return m.ReturnedID, nil }
+func (m *noteIndexAddMock) Update(note Note) error                              { return nil }
+func (m *noteIndexAddMock) Remove(path string) error                            { return nil }
+func (m *noteIndexAddMock) BatchUpdateLinks(ids []NoteID, paths []string) error { return nil }
+func (m *noteIndexAddMock) Commit(transaction func(idx NoteIndex) error) error  { return nil }
+func (m *noteIndexAddMock) NeedsReindexing() (bool, error)                      { return false, nil }
+func (m *noteIndexAddMock) SetNeedsReindexing(needsReindexing bool) error       { return nil }

--- a/internal/core/notebook.go
+++ b/internal/core/notebook.go
@@ -174,7 +174,7 @@ func (n *Notebook) NewNote(opts NewNoteOpts) (*Note, error) {
 	}
 
 	if !opts.DryRun {
-		id, err := n.index.Add(*note)
+		id, err := n.index.Add(*note, true)
 		if err != nil {
 			return nil, fmt.Errorf("new note: %w", err)
 		}


### PR DESCRIPTION
This PR brings the time to index the large test data (`make testdata`) from 7min to ~8sec.

The main performance bottleneck was the compilation of dynamic regexes. The patterns they matched were simple enough to be converted into normal string searches.

The second bottleneck was the systematic link update when adding a new note.
Now we put new notes in an array, and update all links together in parallel afterward.
When adding a single file (`zk new`) we do the same parallel update but for a single file.