### PR TITLE
LocationLink response should be an array

### DIFF
--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -326,10 +326,10 @@ func NewServer(opts ServerOpts) *Server {
 		}
 
 		if definitionLinkSupport(clientCapabilities) {
-			return protocol.LocationLink{
+			return []protocol.LocationLink{{
 				OriginSelectionRange: &link.Range,
 				TargetURI:            target.URI,
-			}, nil
+			}}, nil
 		} else {
 			return protocol.Location{
 				URI: target.URI,


### PR DESCRIPTION
Unlike Location which could be a single element or an array, LocationLink must always be an array in a response: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_definition

Fixes #737 