### PR TITLE
Allow for date+time filtering with `"<date> <time>"` as well as `<date>T<time>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Format: `<description> (by <contributor>, <pr number>)`
 ### Fixed
 
 - Indexing made significantly more performant (by @Keluaa, 735)
+- Support filtering by date and time with `"<date> <time>"` instead of
+  `<date>T<time>` only (by @tjex, 743)
 
 ## 0.15.5
 

--- a/docs/notes/note-filtering.md
+++ b/docs/notes/note-filtering.md
@@ -256,6 +256,15 @@ You can filter by range instead, using `--created-before`, `--created-after`,
 --created-after "last monday" --created-before yesterday
 ```
 
+Specifying a date and time can be in two formats:
+
+```
+--created-after 2026-06-01T15:00 --created-before 2026-06-01T18:00
+
+# Must be wrapped in quotes when ommitting 'T'
+--created-after "2026-06-01 15:00" --created-before "2026-06-01 18:00"
+```
+
 ## Explore links
 
 You can use the following options to explore the web of links spanning your

--- a/internal/util/date/date.go
+++ b/internal/util/date/date.go
@@ -46,7 +46,13 @@ func TimeFromNatural(date string) (time.Time, error) {
 	if t, err := time.ParseInLocation("2006-01-02T15:04:05", date, time.Local); err == nil {
 		return t, nil
 	}
+	if t, err := time.ParseInLocation("2006-01-02 15:04:05", date, time.Local); err == nil {
+		return t, nil
+	}
 	if t, err := time.ParseInLocation("2006-01-02T15:04", date, time.Local); err == nil {
+		return t, nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02 15:04", date, time.Local); err == nil {
 		return t, nil
 	}
 	if t, err := time.ParseInLocation("2006-01-02", date, time.Local); err == nil {

--- a/tests/cmd-list-filter-date.tesh
+++ b/tests/cmd-list-filter-date.tesh
@@ -4,6 +4,14 @@ $ cd full-sample
 $ zk list -qf\{{title}} --created 2011-05-16T09:58:57Z
 >When to prefer PUT over POST HTTP method?
 
+# List a note created on a given day (alternate datetime format).
+$ zk list -qf\{{title}} --created "2011-05-16 09:58:57"
+>When to prefer PUT over POST HTTP method?
+
+# List a note created on a given day (alternate datetime format).
+$ zk list -qf\{{title}} --created-after "2011-05-16 09:58" --created-before "2011-05-16 09:59"
+>When to prefer PUT over POST HTTP method?
+
 # List notes created today.
 $ zk list -qf\{{title}} --created today
 >Buy low, sell high


### PR DESCRIPTION
Resolves zk-org/zk#742

Currently date and time filtering was achieved like so:
`zk list --created-after 2026-06-01T15:00`

This PR enables `zk list --created-after "2026-06-01 15:00"`

Likewise with second precision. 

