### PR TITLE
LSP: resolve leading-slash links against the notebook root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: `<description> (by <contributor>, <pr number>)`
 
 ## Unreleased
 
+### Fixed
+
+- Resolve links with a leading slash against the notebook root, falling back to
+  the filesystem for absolute paths (by @zmre, 745)
+
 ## 0.15.6
 
 ### Added

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -547,15 +547,37 @@ func (s *Server) noteForLink(link documentLink, notebook *core.Notebook) (*Note,
 
 // noteForHref returns the Note object for the note targeted by the given HREF
 // relative to relativeToDir.
+//
+// If there's a leading slash, resolve against the notebook root first to match
+// most Markdown renderers. Fallback to the filesystem root.
 func (s *Server) noteForHref(href string, relativeToDir string, notebook *core.Notebook) (*core.MinimalNote, error) {
 	if strutil.IsURL(href) {
 		return nil, nil
+	}
+
+	if strings.HasPrefix(href, "/") || filepath.IsAbs(href) {
+		note, err := s.noteForPath(filepath.Join(notebook.Path, href), href, notebook)
+		if note != nil || err != nil {
+			return note, err
+		}
+		if !filepath.IsAbs(href) {
+			// A rooted but non-absolute path (e.g. /foo on Windows) can't be
+			// made relative to the notebook, so don't attempt the fallback.
+			return nil, nil
+		}
+		return s.noteForPath(filepath.Clean(href), href, notebook)
 	}
 
 	path := href
 	if relativeToDir != "" {
 		path = filepath.Clean(filepath.Join(relativeToDir, path))
 	}
+	return s.noteForPath(path, href, notebook)
+}
+
+// noteForPath returns the Note object for the note at the given absolute
+// filesystem path, or nil if it doesn't target a note in the notebook.
+func (s *Server) noteForPath(path string, href string, notebook *core.Notebook) (*core.MinimalNote, error) {
 	path, err := filepath.Rel(notebook.Path, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve href: %s: %w", href, err)

--- a/internal/adapter/lsp/server_test.go
+++ b/internal/adapter/lsp/server_test.go
@@ -224,3 +224,115 @@ func TestDefinitionLinkSupport_NilCapabilities(t *testing.T) {
 	}
 	assert.Equal(t, definitionLinkSupport(caps), true)
 }
+
+func TestServer_noteForHref(t *testing.T) {
+	fixture := getNotebookFixture("links")
+
+	fs, err := fs.NewFileStorage(fixture.Path, &util.NullLogger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.FS = fs
+
+	// Setup DB
+	db, err := sqlite.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	config := core.NewDefaultConfig()
+	index := sqlite.NewNoteIndex(fixture.Path, db, &util.NullLogger, config.Note.Extension)
+
+	// Initialize markdown parser directly
+	parser := markdown.NewParser(markdown.ParserOpts{
+		HashtagEnabled: true,
+	}, &util.NullLogger)
+
+	notebook := core.NewNotebook(fixture.Path, config, core.NotebookPorts{
+		NoteIndex:         index,
+		NoteContentParser: parser,
+		FS:                fs,
+		TemplateLoaderFactory: func(lang string) (core.TemplateLoader, error) {
+			return &core.NullTemplateLoader, nil
+		},
+		Logger: &util.NullLogger,
+	})
+	if _, err := notebook.Index(core.NoteIndexOpts{
+		Force:   true,
+		Verbose: false,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	server := &Server{
+		documents: newDocumentStore(fs, &util.NullLogger),
+		logger:    &util.NullLogger,
+	}
+
+	tests := []struct {
+		name          string
+		href          string
+		relativeToDir string
+		// Expected note path relative to the notebook root, or "" when no
+		// note should be found.
+		wantPath string
+	}{{
+		name:          "relative to the note's directory",
+		href:          "note-a",
+		relativeToDir: filepath.Join(fixture.Path, "sub"),
+		wantPath:      "sub/note-a.md",
+	}, {
+		name:          "relative with parent traversal",
+		href:          "../top",
+		relativeToDir: filepath.Join(fixture.Path, "sub"),
+		wantPath:      "top.md",
+	}, {
+		name:          "notebook-root path from a nested directory",
+		href:          "/sub/note-a",
+		relativeToDir: filepath.Join(fixture.Path, "sub", "nested"),
+		wantPath:      "sub/note-a.md",
+	}, {
+		name:          "notebook-root path with extension",
+		href:          "/sub/nested/note-b.md",
+		relativeToDir: fixture.Path,
+		wantPath:      "sub/nested/note-b.md",
+	}, {
+		name:          "notebook-root path to a top-level note",
+		href:          "/top",
+		relativeToDir: filepath.Join(fixture.Path, "sub", "nested"),
+		wantPath:      "top.md",
+	}, {
+		name:          "filesystem absolute path fallback",
+		href:          filepath.Join(fixture.Path, "sub", "note-a.md"),
+		relativeToDir: filepath.Join(fixture.Path, "sub"),
+		wantPath:      "sub/note-a.md",
+	}, {
+		name:          "dead notebook-root link",
+		href:          "/does-not-exist",
+		relativeToDir: filepath.Join(fixture.Path, "sub"),
+		wantPath:      "",
+	}, {
+		name:          "URL is ignored",
+		href:          "https://example.com/foo",
+		relativeToDir: filepath.Join(fixture.Path, "sub"),
+		wantPath:      "",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			note, err := server.noteForHref(tt.href, tt.relativeToDir, notebook)
+			assert.Nil(t, err)
+			if tt.wantPath == "" {
+				if note != nil {
+					t.Errorf("expected no note for %s, got %s", tt.href, note.Path)
+				}
+			} else {
+				if note == nil {
+					t.Fatalf("expected note %s for %s, got nil", tt.wantPath, tt.href)
+				}
+				assert.Equal(t, note.Path, tt.wantPath)
+			}
+		})
+	}
+}

--- a/internal/adapter/lsp/testdata/links/.zk/config.toml
+++ b/internal/adapter/lsp/testdata/links/.zk/config.toml
@@ -1,0 +1,11 @@
+[note]
+template = "default.md"
+
+[format.markdown]
+
+link-format = "markdown"
+
+[lsp]
+
+[lsp.diagnostics]
+dead-link = "error"

--- a/internal/adapter/lsp/testdata/links/sub/nested/note-b.md
+++ b/internal/adapter/lsp/testdata/links/sub/nested/note-b.md
@@ -1,0 +1,3 @@
+# Note B
+
+A note in a nested subdirectory.

--- a/internal/adapter/lsp/testdata/links/sub/note-a.md
+++ b/internal/adapter/lsp/testdata/links/sub/note-a.md
@@ -1,0 +1,3 @@
+# Note A
+
+A note in a subdirectory.

--- a/internal/adapter/lsp/testdata/links/top.md
+++ b/internal/adapter/lsp/testdata/links/top.md
@@ -1,0 +1,3 @@
+# Top
+
+A note at the notebook root.


### PR DESCRIPTION
Links like `[Note](/sub/note-a)` are now resolved relative to the notebook root, which aligns with the way most Markdown renderers treat root-relative destinations. So if building notes as a series of web pages, absolute refers to the project root. We still fallback to the filesystem root for absolute to allow links to anything on the drive.

Previously these links were joined onto the current note's directory (ie, `/path/to/note_parent//absolute/link` which I think produced unexpected behaviors in almost all cases, broke go-to-definition, hover, references, and produced false dead-link diagnostics for any links with leading slashes.

This was brought up and closed in #494 , but I believe it has merit and I don't see any downside to supporting this behavior.  Obviously feel free to disagree.

Fixes zk-org/zk#494

> [!NOTE]
> I didn't see anything in `CONTRIBUTING.md` about AI. I'm mostly a rust programmer and have only lightly dabbled in Go, so I did use AI to help me with this fix and especially in generating tests to validate it.  If that's not okay, I completely understand.  I hand wrote aspects and reviewed every line manually and I believe this is a useful contribution of good quality.
