### PR TITLE
Only ignore testdata in repository root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 # Zk specific
 notebook.db
 zk
-testdata/
+/testdata/
 
 # Sphinx Docs / Python #
 # created by `make zkdocs` for building documentation locally


### PR DESCRIPTION
The existing gitignore entry inadvertently ignores other directories named testdata containing fixtures which are committed.