### PR TITLE
fix: Preserve all NoteIndex fields in Commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Format: `<description> (by <contributor>, <pr number>)`
 - Indexing made significantly more performant (by @Keluaa, 735)
 - Support filtering by date and time with `"<date> <time>"` instead of
   `<date>T<time>` only (by @tjex, 743)
+- `NoteIndex.Commit` now passes a complete `NoteIndex` to its transaction
+  instead of one missing the notebook path and note extension (by @ehsash)
 
 ## 0.15.5
 

--- a/internal/adapter/sqlite/note_index.go
+++ b/internal/adapter/sqlite/note_index.go
@@ -345,10 +345,15 @@ func (ni *NoteIndex) Remove(path string) error {
 // Commit implements core.NoteIndex.
 func (ni *NoteIndex) Commit(transaction func(idx core.NoteIndex) error) error {
 	return ni.commit(func(dao *dao) error {
+		// Carry every field over so the index handed to the transaction
+		// behaves like its receiver; a partial copy leaves zero-value fields
+		// that silently diverge from the outer index.
 		return transaction(&NoteIndex{
-			db:     ni.db,
-			dao:    dao,
-			logger: ni.logger,
+			notebookPath: ni.notebookPath,
+			db:           ni.db,
+			dao:          dao,
+			logger:       ni.logger,
+			extension:    ni.extension,
 		})
 	})
 }

--- a/internal/adapter/sqlite/note_index_commit_test.go
+++ b/internal/adapter/sqlite/note_index_commit_test.go
@@ -1,0 +1,30 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/zk-org/zk/internal/core"
+	"github.com/zk-org/zk/internal/util"
+	"github.com/zk-org/zk/internal/util/test/assert"
+)
+
+// Commit hands the transaction a NoteIndex built from the receiver. That index
+// must carry every field of the receiver: the whole indexing pass runs inside
+// this transaction (see Notebook.IndexWithCallback), and linkMatchesPath reads
+// notebookPath to resolve a link relative to its source note. Dropping the
+// field left the transaction resolving links against an empty notebook path.
+func TestNoteIndexCommitPreservesFields(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	index := NewNoteIndex("/notebook", db, &util.NullLogger, "markdown")
+
+	err := index.Commit(func(idx core.NoteIndex) error {
+		inner, ok := idx.(*NoteIndex)
+		assert.True(t, ok)
+		assert.Equal(t, inner.notebookPath, "/notebook")
+		assert.Equal(t, inner.extension, "markdown")
+		return nil
+	})
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
`NoteIndex.Commit` runs its callback against a fresh `NoteIndex` built from the
receiver — but from only three of its five fields:

    func (ni *NoteIndex) Commit(transaction func(idx core.NoteIndex) error) error {
        return ni.commit(func(dao *dao) error {
            return transaction(&NoteIndex{
                db:     ni.db,
                dao:    dao,
                logger: ni.logger,
            })
        })
    }

`notebookPath` and `extension` are left at their zero values, so the index
passed to the transaction is not equivalent to the one it wraps. This matters
because the whole indexing pass runs inside `Commit`
(`Notebook.IndexWithCallback` → `indexTask.execute`), so the wrapped index is
what does all the work.

I couldn't find a case where this changes behaviour on `dev` today, and I don't
want to overstate it:

- `notebookPath` is only read by `relNotebookPath`, where it appears in both
  the `Join` and the `Rel` and cancels out — the result is the same for `""`
  and the real path.
- `extension` is read from the `NoteDAO`, which is built by the outer index and
  reused, not taken from the wrapped index.

The bug is therefore latent rather than observable in the current codebase. It
still seems worth fixing: the zero value of each field is itself valid, so code
later added to the transaction path that reads `notebookPath` or `extension`
from the wrapped index would misbehave silently, with nothing to point at.

The fix carries every field so the wrapped index behaves like its receiver, plus
a test asserting the fields survive `Commit`.