### PR TITLE
update to go 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,9 +172,9 @@ jobs:
         id: vars
         run: echo "version=$(git describe --tags --match v[0-9]* 2> /dev/null)" >> $GITHUB_OUTPUT
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
-          go-version: 1.23
+          go-version: 1.26
       - name: Build
         run: /bin/bash -c 'go build -buildvcs=false -tags "fts5" -ldflags "-X=main.Version=${{ steps.vars.outputs.version }} -X=main.Build=${{ steps.vars.outputs.version }}"'
       - name: Compress for upload.
@@ -199,9 +199,9 @@ jobs:
         id: vars
         run: echo "version=$(git describe --tags --match v[0-9]* 2> /dev/null)" >> $GITHUB_OUTPUT
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
-          go-version: 1.23
+          go-version: 1.26
       - name: Build
         env:
           GOARCH: arm64
@@ -227,9 +227,9 @@ jobs:
         run: echo "version=$(git describe --tags --match v[0-9]* 2> $null)" >> $env:GITHUB_OUTPUT
         shell: pwsh
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
-          go-version: 1.23
+          go-version: 1.26
       - name: Build
         run: go build -buildvcs=false -tags "fts5" -ldflags "-X=main.Version=${{ steps.vars.outputs.version }} -X=main.Build=${{ steps.vars.outputs.version }}"
       - name: Compress for upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v7
         with:
-          go-version: 1.26
+          go-version-file: 'go.mod'
       - name: Build
         run: /bin/bash -c 'go build -buildvcs=false -tags "fts5" -ldflags "-X=main.Version=${{ steps.vars.outputs.version }} -X=main.Build=${{ steps.vars.outputs.version }}"'
       - name: Compress for upload.


### PR DESCRIPTION
Bump outdated actions and go to 1.26 as required for https://github.com/zk-org/zk/pull/751#issuecomment-5043488268