### PR TITLE
Add a disclaimer about the pre-built binaries to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ be released.
 pre-built binaries for macOS, Linux and Windows.
 
 > [!WARNING]
-> The pre-built binaries are not code-signed. Windows Defender and other
-> security tools have flagged the Windows binary as malicious. Building `zk`
-> yourself is currently the recommended workaround on Windows — see
-> [Build from scratch](#build-from-scratch). See
+> The pre-built binaries are not code-signed. In the past Windows Defender and
+> other security tools have flagged some versions of the Windows binary as
+> malicious. Building `zk` yourself is currently the recommended workaround on
+> Windows — see [Build from scratch](#build-from-scratch). See
 > [#740](https://github.com/zk-org/zk/issues/740) for details.
 
 ### Homebrew

--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ be released.
 ## Install
 
 [Check out the latest release](https://github.com/zk-org/zk/releases) for
-pre-built binaries for macOS and Linux (`zk` was not tested on Windows).
+pre-built binaries for macOS, Linux and Windows.
+
+> [!WARNING]
+> The pre-built binaries are not code-signed. Windows Defender and other
+> security tools have flagged the Windows binary as malicious. Building `zk`
+> yourself is currently the recommended workaround on Windows — see
+> [Build from scratch](#build-from-scratch). See
+> [#740](https://github.com/zk-org/zk/issues/740) for details.
 
 ### Homebrew
 


### PR DESCRIPTION
Addresses #740, where the Windows binary from the release page is flagged and
quarantined by Windows Defender.

Following the direction suggested in that discussion, this adds a short
disclaimer to the README and points Windows users to the existing
build-from-source instructions.

Happy to adjust the wording if you would prefer it framed differently.
