### PR TITLE
Deploy docs on version tag instead of merge

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,8 +4,7 @@ name: Deploy GitHub Pages
 
 on:
   push:
-    branches: [main]
-    paths: [docs/**]
+    tags: ["v*.*.*"]
 
 concurrency:
   group: "pages"
@@ -21,5 +20,5 @@ jobs:
       pages: write
       id-token: write
     steps:
-    - id: deployment
-      uses: sphinx-notes/pages@v3
+      - id: deployment
+        uses: sphinx-notes/pages@v3


### PR DESCRIPTION
[Now that we have no more dev branch](https://github.com/zk-org/zk/pull/755#issuecomment-5085163437), the pages deploy action should not run on a
merge to main. 

Instead have it merge on a pushed version tag -- the same as a release. This
way the docs and version releases will be nicely in sync.


