### PR TITLE
feat: add alias support to lsp link completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Format: `<description> (by <contributor>, <pr number>)`
 
 ## Unreleased
 
+-  add alias support to lsp link completion (by @nachoxmacho, 762)
+
 ## 0.15.6
 
 ### Added

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -772,6 +772,44 @@ func (s *Server) buildLinkCompletionList(notebook *core.Notebook, doc *document,
 		}
 
 		items = append(items, item)
+
+		aliases, ok := note.Metadata["aliases"]
+		// If there's no aliases just move to the next note
+		if !ok {
+			continue
+		}
+		switch aliases := aliases.(type) {
+		case []any:
+			for _, alias := range aliases {
+				noteTemp := core.MinimalNote{
+					ID:       note.ID,
+					Metadata: note.Metadata,
+					Path:     note.Path,
+					Title:    fmt.Sprint(alias),
+				}
+
+				item, err := s.newCompletionItem(notebook, noteTemp, doc, position, linkFormatter, templates)
+				if err != nil {
+					s.logger.Err(err)
+					continue
+				}
+				items = append(items, item)
+			}
+		case string:
+			noteTemp := core.MinimalNote{
+				ID:       note.ID,
+				Metadata: note.Metadata,
+				Path:     note.Path,
+				Title:    fmt.Sprint(aliases),
+			}
+
+			item, err := s.newCompletionItem(notebook, noteTemp, doc, position, linkFormatter, templates)
+			if err != nil {
+				s.logger.Err(err)
+				continue
+			}
+			items = append(items, item)
+		}
 	}
 
 	return items, nil


### PR DESCRIPTION
I use aliases fairly commonly in my zettelkasten, and per the docs, zk supports aliases as a concept. In the frontmatter section it says it can be used to filter the output of `zk list`. This works well, however I found myself needing it while writing notes as well. This PR is something I've been using for a while on my own and figure it may be useful to try and merge it back in, in case other find it useful.

It's a simple addition that just loops over each note and generates a completion item that is the same as the note, just with the title changed to the alias. This allows the same completion functionality of the lsp to properly generate for aliases.

I've ran tests locally and they work, and I've been using this with the zk-nvim plugin for over a month now with no bugs. I'm not sure if any documentation is needed for this as when I initially read the documentation stating support for aliases I assumed this would work as well.